### PR TITLE
feat(lap-200): API admin to update lesson and get question

### DIFF
--- a/apps/main-api/src/modules/admin/admin.controller.ts
+++ b/apps/main-api/src/modules/admin/admin.controller.ts
@@ -51,26 +51,26 @@ export class AdminController {
     return this.adminService.updateLesson(id, updateLessonDto);
   }
 
-  @ApiOperation({ summary: "Get all questions grouped by question type" })
+  @ApiOperation({ summary: "Get all questions with query parameters" })
   @ApiQuery({
     name: "contentType",
     type: String,
-    required: true,
+    required: false,
     example: `${ContentTypeEnum.MULTIPLE_CHOICE}+${ContentTypeEnum.FILL_IN_THE_BLANK}`,
   })
-  @ApiQuery({ name: "cerfLevel", type: String, enum: CERFLevelEum, required: true })
+  @ApiQuery({ name: "cerfLevel", type: String, enum: CERFLevelEum, required: false })
   @ApiQuery({ name: "offset", type: Number, required: true })
   @ApiQuery({ name: "limit", type: Number, required: true })
   @ApiResponse({ status: 200, description: "Get all questions successfully" })
   @ApiResponse({ status: 400, description: "Invalid query param" })
   @Get("questions")
   getQuestions(
-    @Query("contentType", new ParseListStringEnumPipe(ContentTypeEnum, "+")) listContentTypes: ContentTypeEnum[],
-    @Query("cerfLevel", new ParseEnumPipe(CERFLevelEum)) cerfLevel: CERFLevelEum,
     @Query("offset", new ParseIntPipe()) offset: number,
-    @Query("limit", new ParseIntPipe()) limit: number
+    @Query("limit", new ParseIntPipe()) limit: number,
+    @Query("contentType", new ParseListStringEnumPipe(ContentTypeEnum, "+")) listContentTypes?: ContentTypeEnum[],
+    @Query("cerfLevel", new ParseEnumPipe(CERFLevelEum, { optional: true })) cerfLevel?: CERFLevelEum
   ) {
-    return this.adminService.getQuestions(listContentTypes, cerfLevel, offset, limit);
+    return this.adminService.getQuestions({ listContentTypes, cerfLevel, offset, limit });
   }
 
   @ApiOperation({ summary: "Update a question" })

--- a/apps/main-api/src/modules/admin/admin.controller.ts
+++ b/apps/main-api/src/modules/admin/admin.controller.ts
@@ -4,6 +4,7 @@ import {
   CreateLessonDto,
   CreateQuestionDto,
   CreateQuestionTypeDto,
+  UpdateLessonDto,
   UpdateQuestionDto,
   UpdateQuestionTypeDto,
 } from "@app/types/dtos/admin";
@@ -39,6 +40,15 @@ export class AdminController {
   @Post("lessons")
   createLesson(@Body() createLessonDto: CreateLessonDto) {
     return this.adminService.createLesson(createLessonDto);
+  }
+
+  @ApiOperation({ summary: "Update a lesson" })
+  @ApiBody({ type: UpdateLessonDto })
+  @ApiResponse({ status: 200, description: "Lesson updated" })
+  @ApiResponse({ status: 400, description: "Not found lesson or question type" })
+  @Put("lessons/:id")
+  updateLesson(@Param("id", ParseIntPipe) id: number, @Body() updateLessonDto: UpdateLessonDto) {
+    return this.adminService.updateLesson(id, updateLessonDto);
   }
 
   @ApiOperation({ summary: "Get all questions grouped by question type" })

--- a/apps/main-api/src/modules/admin/admin.controller.ts
+++ b/apps/main-api/src/modules/admin/admin.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post, Put, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, Param, ParseEnumPipe, ParseIntPipe, Post, Put, Query, UseGuards } from "@nestjs/common";
 import { AdminService } from "./admin.service";
 import {
   CreateLessonDto,
@@ -9,8 +9,9 @@ import {
 } from "@app/types/dtos/admin";
 import { FirebaseJwtAuthGuard, RoleGuard } from "../../guards";
 import { Roles } from "../../decorators";
-import { AccountRoleEnum } from "@app/types/enums";
-import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { AccountRoleEnum, CERFLevelEum, ContentTypeEnum } from "@app/types/enums";
+import { ApiBearerAuth, ApiBody, ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { ParseListStringEnumPipe } from "@app/utils/pipes";
 
 @ApiTags("Admin")
 @ApiBearerAuth()
@@ -41,11 +42,25 @@ export class AdminController {
   }
 
   @ApiOperation({ summary: "Get all questions grouped by question type" })
+  @ApiQuery({
+    name: "contentType",
+    type: String,
+    required: true,
+    example: `${ContentTypeEnum.MULTIPLE_CHOICE}+${ContentTypeEnum.FILL_IN_THE_BLANK}`,
+  })
+  @ApiQuery({ name: "cerfLevel", type: String, enum: CERFLevelEum, required: true })
+  @ApiQuery({ name: "offset", type: Number, required: true })
+  @ApiQuery({ name: "limit", type: Number, required: true })
   @ApiResponse({ status: 200, description: "Get all questions successfully" })
-  @ApiResponse({ status: 400, description: "Error" })
+  @ApiResponse({ status: 400, description: "Invalid query param" })
   @Get("questions")
-  getQuestions() {
-    return this.adminService.getQuestions();
+  getQuestions(
+    @Query("contentType", new ParseListStringEnumPipe(ContentTypeEnum, "+")) listContentTypes: ContentTypeEnum[],
+    @Query("cerfLevel", new ParseEnumPipe(CERFLevelEum)) cerfLevel: CERFLevelEum,
+    @Query("offset", new ParseIntPipe()) offset: number,
+    @Query("limit", new ParseIntPipe()) limit: number
+  ) {
+    return this.adminService.getQuestions(listContentTypes, cerfLevel, offset, limit);
   }
 
   @ApiOperation({ summary: "Update a question" })

--- a/apps/main-api/src/modules/admin/admin.service.ts
+++ b/apps/main-api/src/modules/admin/admin.service.ts
@@ -3,6 +3,7 @@ import {
   CreateLessonDto,
   CreateQuestionDto,
   CreateQuestionTypeDto,
+  UpdateLessonDto,
   UpdateQuestionDto,
   UpdateQuestionTypeDto,
 } from "@app/types/dtos/admin";
@@ -58,15 +59,27 @@ export class AdminService {
 
   async createLesson(createLessonDto: CreateLessonDto): Promise<ILesson> {
     try {
-      const { questionTypeId, bandScore, name } = createLessonDto;
-      const totalLessons = await Lesson.count({
-        where: { questionTypeId, bandScore },
-      });
       return Lesson.save({
-        questionTypeId,
-        bandScore,
-        name,
-        order: totalLessons + 1,
+        ...createLessonDto,
+      });
+    } catch (error) {
+      this.logger.error(error);
+      throw new BadRequestException(error);
+    }
+  }
+
+  async updateLesson(id: number, updateLessonDto: UpdateLessonDto): Promise<ILesson> {
+    const { questionTypeId } = updateLessonDto;
+    try {
+      const lesson = await Lesson.findOneBy({ id });
+      const questionType = await QuestionType.findOneBy({ id: questionTypeId });
+      if (!lesson || !questionType) {
+        throw new BadRequestException("Lesson or question type not found");
+      }
+
+      return Lesson.save({
+        ...lesson,
+        ...updateLessonDto,
       });
     } catch (error) {
       this.logger.error(error);

--- a/apps/main-api/src/modules/admin/admin.service.ts
+++ b/apps/main-api/src/modules/admin/admin.service.ts
@@ -6,7 +6,8 @@ import {
   UpdateQuestionDto,
   UpdateQuestionTypeDto,
 } from "@app/types/dtos/admin";
-import { ILesson, IQuestion, IQuestionType } from "@app/types/interfaces";
+import { CERFLevelEum, ContentTypeEnum } from "@app/types/enums";
+import { ILesson, IListQuestion, IQuestion, IQuestionType } from "@app/types/interfaces";
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import _ from "lodash";
 
@@ -25,10 +26,14 @@ export class AdminService {
     }
   }
 
-  async getQuestions(): Promise<Record<string, IQuestion[]>> {
+  async getQuestions(
+    listContentType: ContentTypeEnum[],
+    cerfLevel: CERFLevelEum,
+    offset: number,
+    limit: number
+  ): Promise<IListQuestion> {
     try {
-      const questions: IQuestion[] = await Question.find();
-      return _.groupBy(questions, (IQuestion) => IQuestion.contentType);
+      return Question.getQuestionsByContentTypesAndCerfLevel(listContentType, cerfLevel, offset, limit);
     } catch (error) {
       this.logger.error(error);
       throw new BadRequestException(error);

--- a/apps/main-api/src/modules/admin/admin.service.ts
+++ b/apps/main-api/src/modules/admin/admin.service.ts
@@ -3,11 +3,11 @@ import {
   CreateLessonDto,
   CreateQuestionDto,
   CreateQuestionTypeDto,
+  QueryParamQuestionDto,
   UpdateLessonDto,
   UpdateQuestionDto,
   UpdateQuestionTypeDto,
 } from "@app/types/dtos/admin";
-import { CERFLevelEum, ContentTypeEnum } from "@app/types/enums";
 import { ILesson, IListQuestion, IQuestion, IQuestionType } from "@app/types/interfaces";
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import _ from "lodash";
@@ -27,14 +27,9 @@ export class AdminService {
     }
   }
 
-  async getQuestions(
-    listContentType: ContentTypeEnum[],
-    cerfLevel: CERFLevelEum,
-    offset: number,
-    limit: number
-  ): Promise<IListQuestion> {
+  async getQuestions(queryParamQuestionDto: QueryParamQuestionDto): Promise<IListQuestion> {
     try {
-      return Question.getQuestionsByContentTypesAndCerfLevel(listContentType, cerfLevel, offset, limit);
+      return Question.getQuestionsWithParams(queryParamQuestionDto);
     } catch (error) {
       this.logger.error(error);
       throw new BadRequestException(error);

--- a/libs/database/src/subscribers/index.ts
+++ b/libs/database/src/subscribers/index.ts
@@ -2,3 +2,4 @@ export * from "./account.subscriber";
 export * from "./learner.subscriber";
 export * from "./activity.subscriber";
 export * from "./lesson-record.subcriber";
+export * from "./lesson.subscriber";

--- a/libs/database/src/subscribers/lesson.subscriber.ts
+++ b/libs/database/src/subscribers/lesson.subscriber.ts
@@ -1,0 +1,53 @@
+import { EventSubscriber, EntitySubscriberInterface, UpdateEvent, InsertEvent, Not } from "typeorm";
+import { Lesson } from "../entities";
+import { ILesson } from "@app/types/interfaces";
+
+@EventSubscriber()
+export class LessonSubscriber implements EntitySubscriberInterface<ILesson> {
+  listenTo(): typeof Lesson {
+    return Lesson;
+  }
+
+  async beforeInsert(event: InsertEvent<ILesson>): Promise<void> {
+    const lesson = event.entity;
+    const currentTotalLessonsCategory = await Lesson.count({
+      where: { questionTypeId: lesson.questionTypeId, bandScore: lesson.bandScore },
+    });
+
+    lesson.order = currentTotalLessonsCategory + 1;
+  }
+
+  async beforeUpdate(event: UpdateEvent<ILesson>): Promise<void> {
+    const previousLessonCategory = event.databaseEntity;
+    const updatedLessonCategory = event.entity;
+
+    // If questionTypeId or bandScore has changed
+    if (
+      updatedLessonCategory.questionTypeId !== previousLessonCategory.questionTypeId ||
+      updatedLessonCategory.bandScore !== previousLessonCategory.bandScore
+    ) {
+      // Get all the lessons with the old questionTypeId and bandScore, ordered by 'order'
+      const listPreviouslessonsCategory = await Lesson.find({
+        where: {
+          id: Not(updatedLessonCategory.id),
+          questionTypeId: previousLessonCategory.questionTypeId,
+          bandScore: previousLessonCategory.bandScore,
+        },
+        order: { order: "ASC" },
+      });
+
+      // Update the 'order' of each lesson
+      for (let i = 0; i < listPreviouslessonsCategory.length; i++) {
+        listPreviouslessonsCategory[i].order = i + 1;
+        await listPreviouslessonsCategory[i].save();
+      }
+
+      const currentTotalLessonsCategory = await Lesson.count({
+        where: { questionTypeId: updatedLessonCategory.questionTypeId, bandScore: updatedLessonCategory.bandScore },
+      });
+
+      // Use this to update directly the 'order' of the updated lesson without triggering the 'afterupdate' hook
+      event.entity.order = currentTotalLessonsCategory + 1;
+    }
+  }
+}

--- a/libs/types/src/dtos/admin/index.ts
+++ b/libs/types/src/dtos/admin/index.ts
@@ -3,3 +3,4 @@ export * from "./update-question.dto";
 export * from "./create-lesson.dto";
 export * from "./create-question-type.dto";
 export * from "./update-question-type.dto";
+export * from "./update-lesson.dto";

--- a/libs/types/src/dtos/admin/index.ts
+++ b/libs/types/src/dtos/admin/index.ts
@@ -4,3 +4,4 @@ export * from "./create-lesson.dto";
 export * from "./create-question-type.dto";
 export * from "./update-question-type.dto";
 export * from "./update-lesson.dto";
+export * from "./query-params-question.dto";

--- a/libs/types/src/dtos/admin/query-params-question.dto.ts
+++ b/libs/types/src/dtos/admin/query-params-question.dto.ts
@@ -1,0 +1,20 @@
+import { CERFLevelEum, ContentTypeEnum } from "@app/types/enums";
+import { IsEnum, IsNumber, IsOptional, Min } from "class-validator";
+
+export class QueryParamQuestionDto {
+  @IsOptional()
+  @IsEnum(ContentTypeEnum, { each: true })
+  listContentTypes: ContentTypeEnum[];
+
+  @IsOptional()
+  @IsEnum(CERFLevelEum)
+  cerfLevel: CERFLevelEum;
+
+  @IsNumber({ allowNaN: false, allowInfinity: false }, { message: "Offset must be a number" })
+  @Min(0, { message: "Offset must be greater than or equal to 0" })
+  offset: number;
+
+  @IsNumber({ allowNaN: false, allowInfinity: false }, { message: "Limit must be a number" })
+  @Min(1, { message: "Limit must be greater than or equal to 1" })
+  limit: number;
+}

--- a/libs/types/src/dtos/admin/update-lesson.dto.ts
+++ b/libs/types/src/dtos/admin/update-lesson.dto.ts
@@ -1,0 +1,15 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateLessonDto } from "./create-lesson.dto";
+import { ApiProperty } from "@nestjs/swagger";
+import { BandScoreEnum } from "@app/types/enums";
+
+export class UpdateLessonDto extends PartialType(CreateLessonDto) {
+  @ApiProperty({ type: "string", example: "Lesson 1", required: false })
+  name?: string;
+
+  @ApiProperty({ type: "string", enum: BandScoreEnum, required: false })
+  bandScore?: BandScoreEnum;
+
+  @ApiProperty({ type: "number", required: false })
+  questionTypeId?: number;
+}

--- a/libs/types/src/dtos/admin/update-question.dto.ts
+++ b/libs/types/src/dtos/admin/update-question.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from "@nestjs/swagger";
+import { PartialType } from "@nestjs/mapped-types";
 import { CreateQuestionDto } from "./create-question.dto";
 
 export class UpdateQuestionDto extends PartialType(CreateQuestionDto) {}

--- a/libs/types/src/interfaces/index.ts
+++ b/libs/types/src/interfaces/index.ts
@@ -26,3 +26,5 @@ export * from "./instruction.interface";
 export * from "./question.interface";
 export * from "./question-to-lesson.interface";
 export * from "./xp-lesson-process.interface";
+
+export * from "./list-question.interface";

--- a/libs/types/src/interfaces/list-question.interface.ts
+++ b/libs/types/src/interfaces/list-question.interface.ts
@@ -1,0 +1,8 @@
+import { IQuestion } from "./question.interface";
+
+export interface IListQuestion {
+  questions: IQuestion[];
+  offset: number;
+  limit: number;
+  total: number;
+}

--- a/libs/utils/src/pipes/index.ts
+++ b/libs/utils/src/pipes/index.ts
@@ -1,1 +1,2 @@
 export * from "./throw-first-error-validation.pipe";
+export * from "./parse-list-string-enum.pipe";

--- a/libs/utils/src/pipes/parse-list-string-enum.pipe.ts
+++ b/libs/utils/src/pipes/parse-list-string-enum.pipe.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, PipeTransform } from "@nestjs/common";
+import _ from "lodash";
 
 @Injectable()
 export class ParseListStringEnumPipe implements PipeTransform {
@@ -8,6 +9,9 @@ export class ParseListStringEnumPipe implements PipeTransform {
   ) {}
 
   transform(value: any) {
+    if (_.isNil(value)) {
+      return null;
+    }
     const values = value.split(this.separator);
 
     if (values.length === 0) {

--- a/libs/utils/src/pipes/parse-list-string-enum.pipe.ts
+++ b/libs/utils/src/pipes/parse-list-string-enum.pipe.ts
@@ -1,0 +1,24 @@
+import { BadRequestException, Injectable, PipeTransform } from "@nestjs/common";
+
+@Injectable()
+export class ParseListStringEnumPipe implements PipeTransform {
+  constructor(
+    private readonly enumType: object,
+    private readonly separator: string
+  ) {}
+
+  transform(value: any) {
+    const values = value.split(this.separator);
+
+    if (values.length === 0) {
+      throw new BadRequestException("Invalid value");
+    }
+
+    return values.map((item: string) => {
+      if (!Object.values(this.enumType).includes(item)) {
+        throw new BadRequestException(`Invalid value: ${item}`);
+      }
+      return item;
+    });
+  }
+}


### PR DESCRIPTION
1. Update lesson information
- if change `questionTypeId` or `bandScore`: reorder list lessons of previous category & append this lesson to the last order of new category

2. Get questions with quey parameter
- return data with list questions,  offset, limit, and total of those categories