### PR TITLE
feat(lap-283): update band score of question type of learner

### DIFF
--- a/apps/main-api/src/migrations/1728099079758-add_column_band_score_requires_question_type.ts
+++ b/apps/main-api/src/migrations/1728099079758-add_column_band_score_requires_question_type.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddColumnBandScoreRequiresQuestionType1728099079758 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      "question_types",
+      new TableColumn({
+        name: "band_score_requires",
+        type: "jsonb",
+        isNullable: true,
+      })
+    );
+  }
+
+  public async down(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/apps/main-api/src/modules/admin/admin.service.ts
+++ b/apps/main-api/src/modules/admin/admin.service.ts
@@ -14,6 +14,7 @@ import { ILesson, IListQuestion, IQuestion, IQuestionType } from "@app/types/int
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import _ from "lodash";
 import { In } from "typeorm";
+import { DEFAULT_BAND_SCORE_REQUIRES } from "@app/types/constants";
 
 @Injectable()
 export class AdminService {
@@ -89,6 +90,7 @@ export class AdminService {
     try {
       return QuestionType.save({
         ...dto,
+        bandScoreRequires: DEFAULT_BAND_SCORE_REQUIRES,
       });
     } catch (error) {
       this.logger.error(error);
@@ -120,7 +122,7 @@ export class AdminService {
     try {
       const { reorderLessons, ...restDto } = dto;
 
-      // Must be changed if use subscribers
+      // Must be changed if you use subscribers
       const questionType = await QuestionType.findOneBy({ id });
 
       if (!questionType) {

--- a/apps/main-api/src/modules/daily-lesson/daily-lesson.service.ts
+++ b/apps/main-api/src/modules/daily-lesson/daily-lesson.service.ts
@@ -18,7 +18,7 @@ export class DailyLessonService {
         return {
           ...rest,
           progress: {
-            bandScore: currentProcess.bandScore || BandScoreEnum.PRE_IELTS,
+            bandScore: currentProcess?.bandScore || BandScoreEnum.PRE_IELTS,
             totalLearningXP,
           },
         };

--- a/libs/database/src/entities/lesson-record.entity.ts
+++ b/libs/database/src/entities/lesson-record.entity.ts
@@ -45,7 +45,7 @@ export class LessonRecord extends BaseEntity implements ILessonRecord {
   duration: number;
 
   // Relations
-  @ManyToOne(() => Lesson, (lesson) => lesson.id)
+  @ManyToOne(() => Lesson, (lesson) => lesson.id, { eager: true })
   @JoinColumn({ name: "lesson_id", referencedColumnName: "id" })
   readonly lesson: Lesson;
 

--- a/libs/database/src/entities/question-type.entity.ts
+++ b/libs/database/src/entities/question-type.entity.ts
@@ -1,5 +1,5 @@
 import { SkillEnum } from "@app/types/enums";
-import { IQuestionType } from "@app/types/interfaces";
+import { IBandScoreRequire, IQuestionType } from "@app/types/interfaces";
 import {
   BaseEntity,
   Column,
@@ -30,6 +30,9 @@ export class QuestionType extends BaseEntity implements IQuestionType {
 
   @Column({ name: "image_id", type: "uuid", nullable: true })
   imageId: string;
+
+  @Column({ name: "band_score_requires", type: "jsonb", nullable: true })
+  bandScoreRequires: IBandScoreRequire[];
 
   @CreateDateColumn({ name: "created_at", type: "timestamp", nullable: false, default: () => "CURRENT_TIMESTAMP" })
   createdAt: Date;

--- a/libs/database/src/subscribers/lesson-record.subscriber.ts
+++ b/libs/database/src/subscribers/lesson-record.subscriber.ts
@@ -1,80 +1,9 @@
-import { EntitySubscriberInterface, EventSubscriber, InsertEvent } from "typeorm";
-import { Lesson, LessonProcess, LessonRecord } from "../entities";
+import { EntitySubscriberInterface, EventSubscriber } from "typeorm";
+import { LessonRecord } from "../entities";
 
 @EventSubscriber()
 export class LessonRecordSubscriber implements EntitySubscriberInterface<LessonRecord> {
   listenTo(): typeof LessonRecord {
     return LessonRecord;
-  }
-
-  async afterInsert(event: InsertEvent<LessonRecord>): Promise<void> {
-    const { entity, manager } = event;
-
-    const lesson = await manager.getRepository(Lesson).findOneBy({ id: entity.lessonId });
-
-    const lessonProcess = await manager
-      .getRepository(LessonProcess)
-      .createQueryBuilder("lesson_processes")
-      .leftJoinAndSelect("lesson_processes.currentLesson", "currentLesson")
-      .where("lesson_processes.learner_profile_id = :learnerProfileId", { learnerProfileId: entity.learnerProfileId })
-      .andWhere("lesson_processes.question_type_id = :questionTypeId", { questionTypeId: lesson.questionTypeId })
-      .andWhere("lesson_processes.band_score = :bandScore", { bandScore: lesson.bandScore })
-      .getOne();
-
-    const { bonusXP: xp } = entity.getBonusResources();
-
-    const nextLesson = await manager.getRepository(Lesson).findOneBy({
-      questionTypeId: lessonProcess ? lessonProcess.questionTypeId : lesson.questionTypeId,
-      bandScore: lessonProcess ? lessonProcess.bandScore : lesson.bandScore,
-      order: lessonProcess ? lessonProcess.currentLesson.order + 1 : lesson.order + 1,
-    });
-
-    // Update lesson process
-    if (!lessonProcess) {
-      await manager.getRepository(LessonProcess).save({
-        learnerProfileId: entity.learnerProfileId,
-        questionTypeId: lesson.questionTypeId,
-        currentLesson: nextLesson || lesson,
-        bandScore: lesson.bandScore,
-        xp: [
-          {
-            lessonId: entity.lessonId,
-            xp,
-            duration: entity.duration,
-          },
-        ],
-      });
-    } else {
-      // Check if lesson is already completed
-      const lessonIndex = lessonProcess.xp.findIndex((xp) => xp.lessonId === entity.lessonId);
-
-      if (lessonIndex !== -1) {
-        // Always update the duration
-        lessonProcess.xp[lessonIndex].duration += entity.duration;
-
-        // Update lesson in lesson process
-        lessonProcess.xp[lessonIndex].duration += entity.duration;
-        // The most XP (accuracy) will be prioritized
-        if (xp > lessonProcess.xp[lessonIndex].xp) {
-          lessonProcess.xp[lessonIndex].xp = xp;
-        }
-
-        // Update current lesson to next lesson, this is the case when add new lesson to the list
-        if (nextLesson && lessonProcess.currentLesson.id === entity.lessonId) {
-          lessonProcess.currentLesson = nextLesson;
-        }
-      } else {
-        // Add new lesson to lesson process
-        lessonProcess.xp.push({
-          lessonId: entity.lessonId,
-          xp,
-          duration: entity.duration,
-        });
-
-        nextLesson && (lessonProcess.currentLesson = nextLesson);
-      }
-
-      await lessonProcess.save();
-    }
   }
 }

--- a/libs/types/src/constants/default-band-score-requires.constant.ts
+++ b/libs/types/src/constants/default-band-score-requires.constant.ts
@@ -1,0 +1,33 @@
+import { IBandScoreRequire } from "@app/types/interfaces";
+import { BandScoreEnum } from "@app/types/enums";
+
+export const DEFAULT_BAND_SCORE_REQUIRES: IBandScoreRequire[] = [
+  {
+    bandScore: BandScoreEnum.PRE_IELTS,
+    requireXP: 500,
+  },
+  {
+    bandScore: BandScoreEnum.BAND_4_5,
+    requireXP: 500,
+  },
+  {
+    bandScore: BandScoreEnum.BAND_5_0,
+    requireXP: 500,
+  },
+  {
+    bandScore: BandScoreEnum.BAND_5_5,
+    requireXP: 500,
+  },
+  {
+    bandScore: BandScoreEnum.BAND_6_0,
+    requireXP: 500,
+  },
+  {
+    bandScore: BandScoreEnum.BAND_6_5,
+    requireXP: 500,
+  },
+  {
+    bandScore: BandScoreEnum.BAND_7_0,
+    requireXP: 500,
+  },
+];

--- a/libs/types/src/constants/index.ts
+++ b/libs/types/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * from "./role-key.constant";
 export * from "./redis-provider.constant";
+export * from "./default-band-score-requires.constant";

--- a/libs/types/src/dtos/admin/update-question-type.dto.ts
+++ b/libs/types/src/dtos/admin/update-question-type.dto.ts
@@ -16,6 +16,17 @@ class ReorderLessonDto {
   order: number;
 }
 
+class BandScoreRequireDto {
+  @ApiProperty({ type: "string", enum: BandScoreEnum, example: "5.0" })
+  @IsEnum(BandScoreEnum, { message: "Invalid band score" })
+  bandScore: BandScoreEnum;
+
+  @ApiProperty({ type: Number, example: 100 })
+  @IsInt()
+  @Min(1, { message: "Require XP must be positive" })
+  requireXP: number;
+}
+
 export class UpdateQuestionTypeDto extends PartialType(CreateQuestionTypeDto) {
   @ApiProperty({ type: [ReorderLessonDto] })
   @IsOptional()
@@ -28,4 +39,11 @@ export class UpdateQuestionTypeDto extends PartialType(CreateQuestionTypeDto) {
   @ValidateIf((dto) => dto.bandScore || (dto.reorderLessons && dto.reorderLessons.length > 0))
   @IsEnum(BandScoreEnum, { message: "Invalid band score" })
   bandScore: BandScoreEnum;
+
+  @ApiProperty({ type: [BandScoreRequireDto] })
+  @IsOptional()
+  @ArrayNotEmpty({ message: "Band score requires must not be empty" })
+  @ValidateNested({ each: true })
+  @Type(() => BandScoreRequireDto)
+  bandScoreRequires: BandScoreRequireDto[];
 }

--- a/libs/types/src/dtos/learners/update-resources.dto.ts
+++ b/libs/types/src/dtos/learners/update-resources.dto.ts
@@ -1,5 +1,4 @@
 export class UpdateResourcesDto {
   bonusXP?: number;
   bonusCarrot?: number;
-  bonusStreakPoint?: number;
 }

--- a/libs/types/src/enums/milestones.enum.ts
+++ b/libs/types/src/enums/milestones.enum.ts
@@ -3,4 +3,5 @@ export enum MileStonesEnum {
   IS_RANK_UP = "rank_up",
   IS_OVER_TARGET = "over_target",
   IS_DAILY_STREAK = "daily_streak",
+  IS_BAND_SCORE_QUESTION_TYPE_UP = "band_score_question_type_up",
 }

--- a/libs/types/src/interfaces/band-score-require.interface.ts
+++ b/libs/types/src/interfaces/band-score-require.interface.ts
@@ -1,0 +1,6 @@
+import { BandScoreEnum } from "@app/types/enums";
+
+export interface IBandScoreRequire {
+  bandScore: BandScoreEnum;
+  requireXP: number;
+}

--- a/libs/types/src/interfaces/index.ts
+++ b/libs/types/src/interfaces/index.ts
@@ -34,3 +34,4 @@ export * from "./learner-profile-info.interface";
 export * from "./milestone-info.interfaces";
 
 export * from "./decoded-token.interface";
+export * from "./band-score-require.interface";

--- a/libs/types/src/interfaces/milestone-info.interfaces.ts
+++ b/libs/types/src/interfaces/milestone-info.interfaces.ts
@@ -1,7 +1,7 @@
-import { MileStonesEnum, RankEnum } from "@app/types/enums";
+import { BandScoreEnum, MileStonesEnum, RankEnum } from "@app/types/enums";
 import { ILevel } from "@app/types/interfaces/level.interface";
 
 export interface IMileStoneInfo {
   type: MileStonesEnum;
-  newValue: ILevel | RankEnum | number;
+  newValue: ILevel | RankEnum | number | BandScoreEnum;
 }

--- a/libs/types/src/interfaces/question-type.interface.ts
+++ b/libs/types/src/interfaces/question-type.interface.ts
@@ -3,12 +3,14 @@ import { IBucket } from "./bucket.interface";
 import { IInstruction } from "./instruction.interface";
 import { ILessonProcess } from "./lesson-process.interface";
 import { ILesson } from "./lesson.interface";
+import { IBandScoreRequire } from "@app/types/interfaces/band-score-require.interface";
 
 export interface IQuestionType {
   id: number;
   name: string;
   skill: SkillEnum;
   imageId: string;
+  bandScoreRequires: IBandScoreRequire[];
   createdAt: Date;
   updatedAt: Date;
 

--- a/libs/utils/src/maps/index.ts
+++ b/libs/utils/src/maps/index.ts
@@ -1,1 +1,2 @@
 export * from "./level-rank.map";
+export * from "./next-band-score.map";

--- a/libs/utils/src/maps/next-band-score.map.ts
+++ b/libs/utils/src/maps/next-band-score.map.ts
@@ -1,0 +1,10 @@
+import { BandScoreEnum } from "@app/types/enums";
+
+export const NextBandScoreMap = new Map<BandScoreEnum, BandScoreEnum>([
+  [BandScoreEnum.PRE_IELTS, BandScoreEnum.BAND_4_5],
+  [BandScoreEnum.BAND_4_5, BandScoreEnum.BAND_5_0],
+  [BandScoreEnum.BAND_5_0, BandScoreEnum.BAND_5_5],
+  [BandScoreEnum.BAND_5_5, BandScoreEnum.BAND_6_0],
+  [BandScoreEnum.BAND_6_0, BandScoreEnum.BAND_6_5],
+  [BandScoreEnum.BAND_6_5, BandScoreEnum.BAND_7_0],
+]);


### PR DESCRIPTION
- Run migration to add column `band_score_requires` and assign this sample value
`[{"bandScore": "pre_ielts", "requireXP": 100}, {"bandScore": "4.5", "requireXP": 500}, {"bandScore": "5.0", "requireXP": 500}, {"bandScore": "5.5", "requireXP": 500}, {"bandScore": "6.0", "requireXP": 500}, {"bandScore": "6.5", "requireXP": 500}, {"bandScore": "7.0", "requireXP": 500}]`

- Test all the logic which is as same as `complete lesson feature`
- Check milestone band score up (modify the value of `requireXP`  to be smaller to test easily