### PR TITLE
refactor(lap-332): change usage meaning of profile mission table

### DIFF
--- a/apps/main-api/src/migrations/1728916237944-change_table_profile_missions_name.ts
+++ b/apps/main-api/src/migrations/1728916237944-change_table_profile_missions_name.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChangeTableProfileMissionsName1728916237944 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE profile_missions RENAME TO profile_missions_progress`);
+  }
+
+  public async down(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/apps/main-api/src/modules/mission/mission.helper.ts
+++ b/apps/main-api/src/modules/mission/mission.helper.ts
@@ -1,23 +1,21 @@
-import { IProfileMission } from "@app/types/interfaces";
+import { IMission, IProfileMissionProgress } from "@app/types/interfaces";
 import { Injectable } from "@nestjs/common";
 
 @Injectable()
 export class MissionHelper {
-  buildMissionsResponseData(data: IProfileMission[]) {
-    const response =
-      data.length === 0
-        ? []
-        : data.map((item) => {
-            return {
-              interval: item?.mission?.types,
-              name: item?.mission?.quest?.name,
-              description: item?.mission?.quest?.description,
-              current: item?.current,
-              quantity: item?.mission?.quantity,
-              rewards: item?.mission?.quest?.rewards,
-            };
-          });
-
-    return response;
+  buildMissionsResponseData(profileProgress: IProfileMissionProgress[], missions: IMission[]) {
+    return missions.length === 0
+      ? []
+      : missions.map((mission) => {
+          const progress = profileProgress.find((item) => item.missionId === mission.id);
+          return {
+            interval: mission.types,
+            name: mission.quest.name,
+            description: mission.quest.description,
+            current: progress?.current || 0,
+            quantity: mission.quantity,
+            rewards: mission.quest.rewards,
+          };
+        });
   }
 }

--- a/apps/main-api/src/modules/mission/mission.service.ts
+++ b/apps/main-api/src/modules/mission/mission.service.ts
@@ -1,4 +1,4 @@
-import { ProfileMission } from "@app/database";
+import { Mission, ProfileMissionProgress } from "@app/database";
 import { ICurrentUser } from "@app/types/interfaces";
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import { MissionHelper } from "./mission.helper";
@@ -11,8 +11,9 @@ export class MissionService {
 
   async getMissions(user: ICurrentUser) {
     try {
-      const data = await ProfileMission.getMissions(user.profileId);
-      return this.missionHelper.buildMissionsResponseData(data);
+      const missions = await Mission.find();
+      const missionProgress = await ProfileMissionProgress.getMissions(user.profileId);
+      return this.missionHelper.buildMissionsResponseData(missionProgress, missions);
     } catch (error) {
       this.logger.error(error);
       throw new BadRequestException(error);

--- a/apps/main-api/src/modules/user/test/user.stub.ts
+++ b/apps/main-api/src/modules/user/test/user.stub.ts
@@ -10,7 +10,7 @@ import {
   ILevel,
   IProfileBadge,
   IProfileItem,
-  IProfileMission,
+  IProfileMissionProgress,
   IStreak,
 } from "@app/types/interfaces";
 import { mockEmail, mockUid } from "@app/shared-modules/firebase/__mocks__/firebase-auth.service";
@@ -28,7 +28,7 @@ const learnerProfile: ILearnerProfile = {
   streak,
   activities: [] as IActivity[],
   profileItems: [] as IProfileItem[],
-  profileMissions: [] as IProfileMission[],
+  profileMissionsProgress: [] as IProfileMissionProgress[],
   profileBadges: [] as IProfileBadge[],
   lessonRecords: [] as ILessonRecord[],
   lessonProcesses: [] as ILessonProcess[],

--- a/libs/database/src/entities/index.ts
+++ b/libs/database/src/entities/index.ts
@@ -9,7 +9,7 @@ export * from "./streak.entity";
 export * from "./mission.entity";
 export * from "./activity.entity";
 export * from "./profile-badge.entity";
-export * from "./profile-mission.entity";
+export * from "./profile-mission-progress.entity";
 export * from "./profile-item.entity";
 export * from "./bucket.entity";
 export * from "./lesson.entity";

--- a/libs/database/src/entities/learner-profile.entity.ts
+++ b/libs/database/src/entities/learner-profile.entity.ts
@@ -1,5 +1,18 @@
-import { ActionNameEnum, BandScoreEnum, MileStonesEnum, RankEnum } from "@app/types/enums";
-import { ILearnerProfile, ILearnerProfileInfo, ILevel, IMileStoneInfo } from "@app/types/interfaces";
+import {
+  ActionNameEnum,
+  BandScoreEnum,
+  MileStonesEnum,
+  ProfileMissionProgressStatusEnum,
+  RankEnum,
+} from "@app/types/enums";
+import {
+  ILearnerProfile,
+  ILearnerProfileInfo,
+  ILevel,
+  IMileStoneInfo,
+  IMission,
+  IProfileMissionProgress,
+} from "@app/types/interfaces";
 import {
   BaseEntity,
   Column,
@@ -16,7 +29,7 @@ import { Level } from "./level.entity";
 import { Streak } from "./streak.entity";
 import { Activity } from "./activity.entity";
 import { ProfileBadge } from "./profile-badge.entity";
-import { ProfileMission } from "./profile-mission.entity";
+import { ProfileMissionProgress } from "./profile-mission-progress.entity";
 import { ProfileItem } from "./profile-item.entity";
 import { LessonRecord } from "./lesson-record.entity";
 import { LessonProcess } from "./lesson-process.entity";
@@ -75,8 +88,8 @@ export class LearnerProfile extends BaseEntity implements ILearnerProfile {
   @OneToMany(() => ProfileBadge, (profileBadge) => profileBadge.profile)
   readonly profileBadges: ProfileBadge[];
 
-  @OneToMany(() => ProfileMission, (profileMission) => profileMission.profile, { eager: true })
-  readonly profileMissions: ProfileMission[];
+  @OneToMany(() => ProfileMissionProgress, (profileMissionProgress) => profileMissionProgress.profile, { eager: true })
+  readonly profileMissionsProgress: ProfileMissionProgress[];
 
   @OneToMany(() => ProfileItem, (profileItem) => profileItem.profile)
   readonly profileItems: ProfileItem[];
@@ -138,6 +151,30 @@ export class LearnerProfile extends BaseEntity implements ILearnerProfile {
         newValue: this.lessonProcesses.find((lesson) => lesson.questionTypeId === questionTypeId).bandScore,
       });
     return milestones;
+  }
+
+  public async handleMissionComplete(mission: IMission): Promise<IProfileMissionProgress> {
+    let missionProgress = this.profileMissionsProgress.find((m) => m.missionId === mission.id);
+    if (missionProgress) {
+      missionProgress.current += 1;
+      if (missionProgress.current >= mission.quantity) {
+        missionProgress.status = ProfileMissionProgressStatusEnum.COMPLETED;
+      }
+    } else {
+      missionProgress = new ProfileMissionProgress({
+        profileId: this.id,
+        current: 1,
+        status:
+          mission.quantity === 1
+            ? ProfileMissionProgressStatusEnum.COMPLETED
+            : ProfileMissionProgressStatusEnum.ASSIGNED,
+        mission: mission,
+      });
+      this.profileMissionsProgress.push(missionProgress);
+    }
+
+    await missionProgress.save();
+    return missionProgress;
   }
 
   private async isLevelUp(): Promise<boolean> {

--- a/libs/database/src/entities/mission.entity.ts
+++ b/libs/database/src/entities/mission.entity.ts
@@ -12,7 +12,7 @@ import {
   UpdateDateColumn,
 } from "typeorm";
 import { Quest } from "./quest.entity";
-import { ProfileMission } from "./profile-mission.entity";
+import { ProfileMissionProgress } from "./profile-mission-progress.entity";
 
 @Entity({ name: "missions" })
 export class Mission extends BaseEntity implements IMission {
@@ -45,6 +45,6 @@ export class Mission extends BaseEntity implements IMission {
   @JoinColumn({ name: "quest_id", referencedColumnName: "id" })
   quest: Quest;
 
-  @OneToMany(() => ProfileMission, (profileMission) => profileMission.mission)
-  profileMissions: ProfileMission[];
+  @OneToMany(() => ProfileMissionProgress, (profileMissionProgress) => profileMissionProgress.mission)
+  profileMissionsProgress: ProfileMissionProgress[];
 }

--- a/libs/shared-modules/src/mission-factory/mission-factory.service.ts
+++ b/libs/shared-modules/src/mission-factory/mission-factory.service.ts
@@ -7,7 +7,7 @@ import { ILearnerProfile, IMission } from "@app/types/interfaces";
 
 @Injectable()
 export class MissionFactoryService {
-  createMission(mission: IMission, learner: ILearnerProfile) {
+  createMissionService(mission: IMission, learner: ILearnerProfile) {
     const categoryName = mission.quest.category as MissionCategoryNameEnum;
     const group = findMissionGroup(categoryName);
     switch (group) {

--- a/libs/types/src/enums/index.ts
+++ b/libs/types/src/enums/index.ts
@@ -3,7 +3,7 @@ export * from "./interval-type.enum";
 export * from "./role.enum";
 export * from "./gender.enum";
 export * from "./rank.enum";
-export * from "./profile-mission.enum";
+export * from "./profile-mission-progress.enum";
 export * from "./reset-password-action.enum";
 export * from "./bucket-permissions.enum";
 export * from "./bucket-upload-status.enum";

--- a/libs/types/src/enums/profile-mission-progress.enum.ts
+++ b/libs/types/src/enums/profile-mission-progress.enum.ts
@@ -1,4 +1,4 @@
-export enum ProfileMissionStatusEnum {
+export enum ProfileMissionProgressStatusEnum {
   ASSIGNED = "assigned",
   COMPLETED = "completed",
 }

--- a/libs/types/src/interfaces/index.ts
+++ b/libs/types/src/interfaces/index.ts
@@ -14,7 +14,7 @@ export * from "./streak.interface";
 export * from "./level.interface";
 export * from "./activity.interface";
 export * from "./profile-badge.interface";
-export * from "./profile-mission.interface";
+export * from "./profile-mission-progress.interface";
 export * from "./profile-item.interface";
 export * from "./bucket.interface";
 export * from "./lesson-record.interface";

--- a/libs/types/src/interfaces/learner-profile.interface.ts
+++ b/libs/types/src/interfaces/learner-profile.interface.ts
@@ -5,7 +5,7 @@ import { ILessonRecord } from "./lesson-record.interface";
 import { ILevel } from "./level.interface";
 import { IProfileBadge } from "./profile-badge.interface";
 import { IProfileItem } from "./profile-item.interface";
-import { IProfileMission } from "./profile-mission.interface";
+import { IProfileMissionProgress } from "./profile-mission-progress.interface";
 import { IStreak } from "./streak.interface";
 
 export interface ILearnerProfile {
@@ -23,7 +23,7 @@ export interface ILearnerProfile {
   readonly streak: IStreak;
   readonly activities: IActivity[];
   readonly profileBadges: IProfileBadge[];
-  readonly profileMissions: IProfileMission[];
+  readonly profileMissionsProgress: IProfileMissionProgress[];
   readonly profileItems: IProfileItem[];
   readonly lessonRecords: ILessonRecord[];
   readonly lessonProcesses: ILessonProcess[];

--- a/libs/types/src/interfaces/mission.interface.ts
+++ b/libs/types/src/interfaces/mission.interface.ts
@@ -1,5 +1,5 @@
 import { IntervalTypeEnum } from "../enums";
-import { IProfileMission } from "./profile-mission.interface";
+import { IProfileMissionProgress } from "./profile-mission-progress.interface";
 import { IQuest } from "./quest.interface";
 
 export interface IMission {
@@ -12,5 +12,5 @@ export interface IMission {
 
   // Relations
   readonly quest: IQuest;
-  readonly profileMissions: IProfileMission[];
+  readonly profileMissionsProgress: IProfileMissionProgress[];
 }

--- a/libs/types/src/interfaces/profile-mission-progress.interface.ts
+++ b/libs/types/src/interfaces/profile-mission-progress.interface.ts
@@ -1,12 +1,12 @@
-import { ProfileMissionStatusEnum } from "../enums";
+import { ProfileMissionProgressStatusEnum } from "../enums";
 import { ILearnerProfile } from "./learner-profile.interface";
 import { IMission } from "./mission.interface";
 
-export interface IProfileMission {
+export interface IProfileMissionProgress {
   id: string;
   profileId: string;
   missionId: string;
-  status: ProfileMissionStatusEnum;
+  status: ProfileMissionProgressStatusEnum;
   current: number;
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION
- Run migration to update new name of profile mission table
- Complete mission:
1. get list of missions
2. query list of profile mission progress of that learn that is not completed
3. check if that mission is completed, upsert that mission progress of learner

- Get missions:
1. get list of missions
2. get missions progress of learner
3. map information of learner progress to each missions