### PR TITLE
feat(LAP-462): ultimate time item effect

### DIFF
--- a/apps/main-api/src/modules/item/inventory/inventory.service.ts
+++ b/apps/main-api/src/modules/item/inventory/inventory.service.ts
@@ -1,7 +1,6 @@
 import { ProfileItem } from "@app/database";
 import { ICurrentUser } from "@app/types/interfaces";
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
-import { MoreThan } from "typeorm";
 import { ItemEffectFactoryService } from "../item-effect/item-effect-factory.service";
 
 @Injectable()
@@ -13,7 +12,7 @@ export class InventoryService {
   async getInventory(user: ICurrentUser) {
     try {
       const profileItems = await ProfileItem.find({
-        where: { profileId: user.profileId, quantity: MoreThan(0) },
+        where: { profileId: user.profileId },
       });
       const items = await Promise.all(
         profileItems.map(async (profileItem) => {

--- a/apps/main-api/src/modules/item/item-effect/item-effect-factory.service.ts
+++ b/apps/main-api/src/modules/item/item-effect/item-effect-factory.service.ts
@@ -3,6 +3,7 @@ import { RandomGiftItemEffect } from "./random-gift-item.service";
 import { ProfileItem } from "@app/database";
 import { ItemName } from "@app/types/enums";
 import { StreakItemService } from "./streak-freeze-item.service";
+import { UltimateTimeItem } from "./ultimate-time-item.service";
 
 export class ItemEffectFactoryService {
   createItemEffectService(profileItem: ProfileItem) {
@@ -11,6 +12,8 @@ export class ItemEffectFactoryService {
         return new RandomGiftItemEffect(profileItem);
       case ItemName.STREAK_FREEZE:
         return new StreakItemService(profileItem);
+      case ItemName.ULTIMATE_TIME:
+        return new UltimateTimeItem(profileItem);
       default:
         return new DefaultItemEffect();
     }

--- a/apps/main-api/src/modules/item/item-effect/streak-freeze-item.service.ts
+++ b/apps/main-api/src/modules/item/item-effect/streak-freeze-item.service.ts
@@ -46,9 +46,6 @@ export class StreakItemService implements IItemEffectService {
       if (error instanceof EntityNotFoundError) {
         throw new HttpException("ACTION_NOT_FOUND", HttpStatus.INTERNAL_SERVER_ERROR);
       }
-      if (error instanceof HttpException) {
-        throw error;
-      }
       throw new BadRequestException(error);
     }
   }

--- a/apps/main-api/src/modules/item/item-effect/ultimate-time-item.service.ts
+++ b/apps/main-api/src/modules/item/item-effect/ultimate-time-item.service.ts
@@ -1,0 +1,46 @@
+import { IItemEffectService } from "./item-effect-abstract.service";
+import { BadRequestException, HttpException, Logger } from "@nestjs/common";
+import { LearnerProfile, ProfileItem } from "@app/database";
+import { ProfileItemStatusEnum } from "@app/types/enums";
+
+export class UltimateTimeItem implements IItemEffectService {
+  private readonly logger = new Logger(UltimateTimeItem.name);
+  private readonly _profileItem: ProfileItem;
+  private readonly _learner: LearnerProfile;
+  private readonly TIME = 15 * 60 * 1000; // 15 minutes
+
+  constructor(_profileItem: ProfileItem) {
+    this._profileItem = _profileItem;
+    this._learner = _profileItem.profile;
+  }
+
+  async applyEffect() {
+    try {
+      // Add one item to the current effect in use
+      if (this._profileItem.expAt && this._profileItem.expAt.getTime() > Date.now()) {
+        this._profileItem.inUseQuantity += 1;
+        this._profileItem.status = ProfileItemStatusEnum.IN_USE;
+        this._profileItem.expAt = new Date(
+          (this._profileItem.expAt ? this._profileItem.expAt.getTime() : Date.now()) + this.TIME
+        );
+      } else {
+        // Create new effect
+        this._profileItem.inUseQuantity = 1;
+        this._profileItem.status = ProfileItemStatusEnum.IN_USE;
+        this._profileItem.expAt = new Date(Date.now() + this.TIME);
+      }
+      // Subtract 1 item from inventory
+      this._profileItem.quantity -= 1;
+      await this._profileItem.save();
+      return {
+        type: this._profileItem.item.name,
+      };
+    } catch (error) {
+      this.logger.error(error);
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new BadRequestException(error);
+    }
+  }
+}

--- a/apps/main-api/src/modules/lesson/lesson.service.ts
+++ b/apps/main-api/src/modules/lesson/lesson.service.ts
@@ -33,12 +33,12 @@ export class LessonService {
 
       const { bonusXP, bonusCarrot } = lessonRecord.getBonusResources();
 
-      await learner.updateResources({ bonusXP, bonusCarrot });
+      const result = await learner.updateResources({ bonusXP, bonusCarrot });
 
       const profileMilestones = await learner.getProfileMileStones();
       const learnProgressMilestones = await learner.getLearnProcessMileStones(
         dto,
-        bonusXP,
+        result.bonusXP,
         currentLesson.questionType.id
       );
 
@@ -68,8 +68,7 @@ export class LessonService {
 
       return {
         ...lessonRecord,
-        bonusXP,
-        bonusCarrot,
+        ...result,
         milestones: [
           ...profileMilestones,
           ...learnProgressMilestones,

--- a/libs/database/src/entities/activity.entity.ts
+++ b/libs/database/src/entities/activity.entity.ts
@@ -34,7 +34,6 @@ export class Activity extends BaseEntity implements IActivity {
 
     const beginOfDay = begin ?? getBeginOfOffsetDay();
     const endOfDay = end ?? getEndOfOffsetDay();
-    console.log(beginOfDay, endOfDay);
 
     const activity = await Activity.findOne({
       where: {
@@ -43,7 +42,6 @@ export class Activity extends BaseEntity implements IActivity {
         finishedAt: Between(beginOfDay, endOfDay),
       },
     });
-    console.log("isHaveActivity", activity);
 
     return activity ? 0 : 1;
   }

--- a/libs/database/src/entities/learner-profile.entity.ts
+++ b/libs/database/src/entities/learner-profile.entity.ts
@@ -110,10 +110,13 @@ export class LearnerProfile extends BaseEntity implements ILearnerProfile {
 
   public async updateResources(newBonusResources: UpdateResourcesDto): Promise<UpdateResourcesDto> {
     const { bonusCarrot = 0, bonusXP = 0 } = newBonusResources;
+    let isDoubleXP = false;
     this.carrots += bonusCarrot;
-    const isDoubleXP = this.profileItems.find(
-      (item) => item.item.name === ItemName.ULTIMATE_TIME && item.status === ProfileItemStatusEnum.IN_USE
-    );
+    const ultimateTime = this.profileItems.find((item) => item.item.name === ItemName.ULTIMATE_TIME);
+    if (ultimateTime) {
+      await ultimateTime.resetItemStatus();
+      isDoubleXP = ultimateTime.status === ProfileItemStatusEnum.IN_USE;
+    }
     this.xp += bonusXP * (isDoubleXP ? 2 : 1);
     await this.save();
     return {

--- a/libs/database/src/entities/profile-item.entity.ts
+++ b/libs/database/src/entities/profile-item.entity.ts
@@ -1,5 +1,5 @@
-import { IProfileItem } from "@app/types/interfaces";
 import {
+  AfterLoad,
   BaseEntity,
   Column,
   CreateDateColumn,
@@ -9,6 +9,7 @@ import {
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from "typeorm";
+import { IProfileItem } from "@app/types/interfaces";
 import { LearnerProfile } from "./learner-profile.entity";
 import { Item } from "./item.entity";
 import { ProfileItemStatusEnum } from "@app/types/enums";
@@ -62,4 +63,14 @@ export class ProfileItem extends BaseEntity implements IProfileItem {
   @ManyToOne(() => Item, (item) => item.id, { eager: true })
   @JoinColumn({ name: "item_id", referencedColumnName: "id" })
   item: Item;
+
+  @AfterLoad()
+  async resetItemStatus() {
+    const now = new Date();
+    if (now >= this.expAt && this.status === ProfileItemStatusEnum.IN_USE) {
+      this.status = ProfileItemStatusEnum.UNUSED;
+      this.inUseQuantity = 0;
+      this.expAt = null;
+    }
+  }
 }


### PR DESCRIPTION
Just a draft PR, following the documents:
- Every actions related to bonusXP in the ultimate time effect should be double.
- If there is a current item in used, use another one make the expire time longer.

Issues:
- The `updateResources` function is not very scalable, a little bit dirty
- Synchronize between the expireAt, status, inUseQuantity and the database. Right now I can only add the @AfterLoad to make sure the data return to client is always true, but cannot sync back to the database (cannot call await this.save()) because it will make the function loop infinite.