### PR TITLE
refactor(lap-486): verify email flow when sign up

### DIFF
--- a/apps/main-api/src/guards/email-verified.guard.ts
+++ b/apps/main-api/src/guards/email-verified.guard.ts
@@ -1,0 +1,13 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { ActionEnum } from "@app/types/enums";
+
+@Injectable()
+export class EmailVerifiedGuard implements CanActivate {
+  constructor() {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const { user } = context.switchToHttp().getRequest();
+
+    return user.action === ActionEnum.VERIFY_MAIL;
+  }
+}

--- a/apps/main-api/src/guards/index.ts
+++ b/apps/main-api/src/guards/index.ts
@@ -1,2 +1,4 @@
 export * from "./firebase-jwt-auth.guard";
 export * from "./role.guard";
+export * from "./email-verified.guard";
+export * from "./reset-password.guard";

--- a/apps/main-api/src/guards/reset-password.guard.ts
+++ b/apps/main-api/src/guards/reset-password.guard.ts
@@ -1,5 +1,5 @@
 import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
-import { ResetPasswordActionEnum } from "@app/types/enums";
+import { ActionEnum } from "@app/types/enums";
 
 @Injectable()
 export class ResetPasswordGuard implements CanActivate {
@@ -8,6 +8,6 @@ export class ResetPasswordGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const { user } = context.switchToHttp().getRequest();
 
-    return user.action === ResetPasswordActionEnum.RESET_PASSWORD;
+    return user.action === ActionEnum.RESET_PASSWORD;
   }
 }

--- a/apps/main-api/src/modules/auth/auth.controller.spec.ts
+++ b/apps/main-api/src/modules/auth/auth.controller.spec.ts
@@ -6,6 +6,7 @@ import { mock_access_token } from "./test/mocks/tokens.mock";
 import { BadRequestException } from "@nestjs/common";
 import { mockEmail } from "@app/shared-modules/firebase/__mocks__/firebase-auth.service";
 import { VerifyOtpDto } from "@app/types/dtos";
+import { ActionEnum } from "@app/types/enums";
 
 jest.mock("./auth.service");
 describe("AuthController", () => {
@@ -70,13 +71,13 @@ describe("AuthController", () => {
       expect(controller.sendOtp).toBeDefined();
     });
     it("should send otp", async () => {
-      const response = await controller.sendOtp(mockEmail);
-      expect(authService.sendOtp).toHaveBeenCalledWith(mockEmail);
+      const response = await controller.sendOtp(mockEmail, ActionEnum.RESET_PASSWORD);
+      expect(authService.sendOtp).toHaveBeenCalledWith(mockEmail, ActionEnum.RESET_PASSWORD);
       expect(response).toEqual(true);
     });
     it("should throw an error when the email is not found", async () => {
       jest.spyOn(authService, "sendOtp").mockRejectedValue(new BadRequestException("Email not found"));
-      const response = controller.sendOtp(mockEmail);
+      const response = controller.sendOtp(mockEmail, ActionEnum.RESET_PASSWORD);
       await expect(response).rejects.toThrow(BadRequestException);
     });
   });
@@ -84,6 +85,7 @@ describe("AuthController", () => {
     const mockOtpRequest: VerifyOtpDto = {
       email: mockEmail,
       otp: "123456",
+      action: ActionEnum.RESET_PASSWORD,
     };
 
     it("otp should be defined", () => {
@@ -91,7 +93,11 @@ describe("AuthController", () => {
     });
     it("should verify otp", async () => {
       const response = await controller.verifyOtp(mockOtpRequest);
-      expect(authService.verifyOtp).toHaveBeenCalledWith(mockOtpRequest.email, mockOtpRequest.otp);
+      expect(authService.verifyOtp).toHaveBeenCalledWith(
+        mockOtpRequest.email,
+        mockOtpRequest.otp,
+        mockOtpRequest.action
+      );
       expect(response).toEqual({
         accessToken: mock_access_token,
       });

--- a/apps/main-api/src/modules/auth/auth.controller.ts
+++ b/apps/main-api/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Query, UseGuards, Request } from "@nestjs/common";
+import { Body, Controller, Get, Post, Query, UseGuards, Request, ParseEnumPipe } from "@nestjs/common";
 import { AuthService } from "./auth.service";
 import {
   LogInUserDto,
@@ -12,6 +12,7 @@ import { ApiBearerAuth, ApiBody, ApiOperation, ApiQuery, ApiResponse, ApiTags } 
 import { FirebaseJwtAuthGuard } from "../../guards";
 import { ResetPasswordGuard } from "../../guards/reset-password.guard";
 import { IResetPasswordAction } from "@app/types/interfaces";
+import { ActionEnum } from "@app/types/enums";
 
 @ApiTags("Authentication")
 @Controller("auth")
@@ -52,7 +53,7 @@ export class AuthController {
   @ApiResponse({ status: 201, description: "OTP verified" })
   @ApiResponse({ status: 406, description: "Expired OTP or Invalid OTP" })
   async verifyOtp(@Body() data: VerifyOtpDto) {
-    return this.authService.verifyOtp(data.email, data.otp);
+    return this.authService.verifyOtp(data.email, data.otp, data.action);
   }
 
   @UseGuards(FirebaseJwtAuthGuard, ResetPasswordGuard)
@@ -63,7 +64,7 @@ export class AuthController {
   @ApiResponse({ status: 200, description: "Password updated" })
   @ApiResponse({ status: 400, description: "Invalid uid" })
   @ApiResponse({ status: 401, description: "Unauthorized" })
-  async resetPassword(@Request() request, @Body() data: ResetPasswordDto) {
+  async resetPassword(@Request() request: any, @Body() data: ResetPasswordDto) {
     const { uid } = request.user as IResetPasswordAction;
     return this.authService.updatePassword(uid, data.newPassword);
   }
@@ -71,10 +72,12 @@ export class AuthController {
   @Get("otp")
   @ApiOperation({ summary: "Send OTP" })
   @ApiQuery({ name: "email", required: true })
+  @ApiQuery({ name: "action", enum: ActionEnum, required: true })
   @ApiResponse({ status: 200, description: "OTP sent" })
+  @ApiResponse({ status: 422, description: "Send mail fail" })
   @ApiResponse({ status: 406, description: "Email not found" })
-  async sendOtp(@Query("email") email: string) {
-    return this.authService.sendOtp(email);
+  async sendOtp(@Query("email") email: string, @Query("action", new ParseEnumPipe(ActionEnum)) action: ActionEnum) {
+    return this.authService.sendOtp(email, action);
   }
 
   @Post("refresh")

--- a/apps/main-api/src/modules/auth/auth.controller.ts
+++ b/apps/main-api/src/modules/auth/auth.controller.ts
@@ -9,10 +9,10 @@ import {
   RefreshTokenRequestDto,
 } from "@app/types/dtos";
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
-import { FirebaseJwtAuthGuard } from "../../guards";
-import { ResetPasswordGuard } from "../../guards/reset-password.guard";
+import { EmailVerifiedGuard, FirebaseJwtAuthGuard, ResetPasswordGuard } from "../../guards";
 import { IResetPasswordAction } from "@app/types/interfaces";
 import { ActionEnum } from "@app/types/enums";
+import { ApiDefaultResponses } from "../../decorators";
 
 @ApiTags("Authentication")
 @Controller("auth")
@@ -67,6 +67,15 @@ export class AuthController {
   async resetPassword(@Request() request: any, @Body() data: ResetPasswordDto) {
     const { uid } = request.user as IResetPasswordAction;
     return this.authService.updatePassword(uid, data.newPassword);
+  }
+
+  @Post("profile")
+  @ApiBearerAuth()
+  @ApiDefaultResponses()
+  @UseGuards(FirebaseJwtAuthGuard, EmailVerifiedGuard)
+  async createNewProfile(@Request() request: any) {
+    const { uid } = request.user as { uid: string };
+    return this.authService.createProfile(uid);
   }
 
   @Get("otp")

--- a/apps/main-api/src/modules/auth/auth.service.spec.ts
+++ b/apps/main-api/src/modules/auth/auth.service.spec.ts
@@ -80,10 +80,11 @@ describe("AuthService", function () {
       jest
         .spyOn(firebaseAuthService, "createUserByEmailAndPassword")
         .mockResolvedValueOnce({ email: signUpRequestMock.email, uid: mockUid } as UserRecord);
-      jest.spyOn(Account, "save").mockResolvedValue({
+      jest.spyOn(Account, "createAccount").mockResolvedValue({
         ...userStub(),
         email: signUpRequestMock.email,
       } as Account);
+      jest.spyOn(service, "sendOtp").mockResolvedValue(true);
       jest.spyOn(firebaseAuthService, "generateCustomToken").mockResolvedValueOnce(mockToken);
       jest
         .spyOn(authHelper, "buildTokenResponse")

--- a/apps/main-api/src/modules/auth/auth.service.spec.ts
+++ b/apps/main-api/src/modules/auth/auth.service.spec.ts
@@ -132,12 +132,12 @@ describe("AuthService", function () {
       jest.spyOn(novuService, "sendEmail").mockResolvedValueOnce({ data: { acknowledged: true } });
       jest.spyOn(redisService, "set").mockResolvedValueOnce(true);
 
-      const result = await service.sendOtp(signInRequestMock.email);
+      const result = await service.sendOtp(signInRequestMock.email, signInRequestMock.action);
       expect(result).toBe(true);
     });
     it("should return false when the email is not exist", async () => {
       findOne.mockResolvedValueOnce(null);
-      const res = await service.sendOtp(signInRequestMock.email);
+      const res = await service.sendOtp(signInRequestMock.email, signInRequestMock.action);
       expect(res).toBe(false);
     });
   });

--- a/apps/main-api/src/modules/auth/auth.service.ts
+++ b/apps/main-api/src/modules/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable, Logger, NotAcceptableException } from "@nestjs/common";
-import { Account } from "@app/database/entities";
+import { Account, LearnerProfile } from "@app/database/entities";
 import { FirebaseAuthService } from "@app/shared-modules/firebase";
 import { AuthHelper } from "./auth.helper";
 import { generate as otpGenerator } from "otp-generator";
@@ -9,7 +9,7 @@ import { IAccount, ICurrentUser } from "@app/types/interfaces";
 import { EntityNotFoundError } from "typeorm";
 import { generateOTPConfig } from "../../config";
 import { NovuService } from "@app/shared-modules/novu";
-import { SEND_OTP_WORKFLOW, VERIFY_EMAIL_WORKFLOW } from "@app/types/constants";
+import { RESET_PASSWORD_WORKFLOW, VERIFY_EMAIL_WORKFLOW } from "@app/types/constants";
 
 @Injectable()
 export class AuthService {
@@ -24,8 +24,9 @@ export class AuthService {
 
   async registerUser(email: string, password: string) {
     try {
-      const firebaseUser = await this.firebaseService.createUserByEmailAndPassword(email, password);
-      await Account.save({ email, providerId: firebaseUser.uid, username: email });
+      const firebaseUser = await this.firebaseService.createUserByEmailAndPassword(email, password, false);
+      await Account.createAccount({ email, providerId: firebaseUser.uid, username: email }, false);
+      await this.sendOtp(email, ActionEnum.VERIFY_MAIL);
       return "Sign up successfully";
     } catch (error) {
       this.logger.error(error);
@@ -37,11 +38,20 @@ export class AuthService {
     try {
       const firebaseUser = await this.firebaseService.verifyOAuthCredential(credential, provider);
       const { email } = firebaseUser;
-      let dbUser: IAccount = await Account.findOne({ where: { email } });
+      let dbUser: IAccount = await Account.findOne({
+        where: { email },
+        relations: {
+          learnerProfile: true,
+        },
+      });
       if (!dbUser) {
         const generatedPassword = otpGenerator(8, generateOTPConfig);
         await this.firebaseService.linkWithProvider(firebaseUser.idToken, firebaseUser.email, generatedPassword);
-        dbUser = await Account.save({ email, providerId: firebaseUser.localId, username: email });
+        dbUser = await Account.createAccount({ email, providerId: firebaseUser.localId, username: email }, true);
+      } else if (!dbUser.learnerProfile) {
+        await this.firebaseService.setEmailVerifed(dbUser.providerId);
+        dbUser.learnerProfile = await LearnerProfile.createNewProfile();
+        dbUser = await Account.save({ ...dbUser }, { reload: true });
       }
       const claims: ICurrentUser = { userId: dbUser.id, profileId: dbUser.learnerProfileId, role: dbUser.role };
       const accessToken = await this.firebaseService.generateCustomToken(dbUser.providerId, claims);
@@ -55,7 +65,16 @@ export class AuthService {
   async login(email: string, password: string) {
     try {
       const firebaseUser = await this.firebaseService.verifyUser(email, password);
-      const dbUser = await Account.findOneOrFail({ where: { providerId: firebaseUser.localId, email } });
+      const dbUser = await Account.findOneOrFail({
+        where: { providerId: firebaseUser.localId, email },
+        relations: {
+          learnerProfile: true,
+        },
+      });
+      if (!dbUser.learnerProfile) {
+        await this.sendOtp(email, ActionEnum.VERIFY_MAIL);
+        return "You have not verified email";
+      }
       const accessToken = await this.firebaseService.generateCustomToken(dbUser.providerId, {
         userId: dbUser.id,
         profileId: dbUser.learnerProfileId,
@@ -86,7 +105,7 @@ export class AuthService {
       await this.redisService.delete(`OTP-${action}-${dbUser.email}`);
       const saved = await this.redisService.set(`OTP-${action}-${dbUser.email}`, { otp, verifyToken });
       if (saved) {
-        const workFlow = action === ActionEnum.RESET_PASSWORD ? SEND_OTP_WORKFLOW : VERIFY_EMAIL_WORKFLOW;
+        const workFlow = action === ActionEnum.RESET_PASSWORD ? RESET_PASSWORD_WORKFLOW : VERIFY_EMAIL_WORKFLOW;
         const res = await this.novuService.sendEmail({ data: { otp } }, dbUser.id, email, workFlow);
 
         return res.data.acknowledged;
@@ -123,6 +142,31 @@ export class AuthService {
       return await this.firebaseService.changePassword(uid, newPassword);
     } catch (error) {
       this.logger.error(error);
+      throw new BadRequestException(error);
+    }
+  }
+
+  async createProfile(uid: string) {
+    try {
+      const account = await Account.findOneOrFail({
+        where: { providerId: uid },
+        relations: {
+          learnerProfile: true,
+        },
+      });
+      if (account.learnerProfile) {
+        return "You already have profile";
+      }
+      await this.firebaseService.setEmailVerifed(uid);
+      const newProfile = await LearnerProfile.createNewProfile();
+      account.learnerProfile = newProfile;
+      await account.save();
+      return "Create new profile successfully";
+    } catch (error) {
+      this.logger.error(error);
+      if (error instanceof EntityNotFoundError) {
+        throw new BadRequestException("Account not found");
+      }
       throw new BadRequestException(error);
     }
   }

--- a/apps/main-api/src/modules/auth/test/requests.mock.ts
+++ b/apps/main-api/src/modules/auth/test/requests.mock.ts
@@ -1,6 +1,9 @@
+import { ActionEnum } from "@app/types/enums";
+
 export const signInRequestMock = {
   email: "exampleSignIn@gmail.com",
   password: "password",
+  action: ActionEnum.RESET_PASSWORD,
 };
 
 export const signUpRequestMock = {

--- a/apps/main-api/src/modules/user/user.service.ts
+++ b/apps/main-api/src/modules/user/user.service.ts
@@ -19,7 +19,7 @@ export class UserService {
       if (firebaseUser) {
         throw new BadRequestException("Email has already existed");
       }
-      firebaseUser = await this.firebaseService.createUserByEmailAndPassword(email, password);
+      firebaseUser = await this.firebaseService.createUserByEmailAndPassword(email, password, true);
       return Account.save({
         email,
         providerId: firebaseUser.uid,

--- a/libs/database/src/entities/account.entity.ts
+++ b/libs/database/src/entities/account.entity.ts
@@ -12,7 +12,6 @@ import {
 } from "typeorm";
 import { LearnerProfile } from "./learner-profile.entity";
 import { Bucket } from "@app/database/entities/bucket.entity";
-
 @Entity("accounts")
 export class Account extends BaseEntity implements IAccount {
   @PrimaryGeneratedColumn("uuid")
@@ -59,9 +58,16 @@ export class Account extends BaseEntity implements IAccount {
 
   @OneToOne(() => LearnerProfile)
   @JoinColumn({ name: "learner_profile_id", referencedColumnName: "id" })
-  readonly learnerProfile: ILearnerProfile;
+  learnerProfile: ILearnerProfile;
 
   @OneToOne(() => Bucket)
   @JoinColumn({ name: "avatar_id", referencedColumnName: "id" })
   readonly avatar: Bucket;
+
+  static async createAccount(data: Partial<IAccount>, isVerified: boolean) {
+    if (isVerified) {
+      data.learnerProfile = await LearnerProfile.createNewProfile();
+    }
+    return await this.save({ ...data });
+  }
 }

--- a/libs/database/src/entities/learner-profile.entity.ts
+++ b/libs/database/src/entities/learner-profile.entity.ts
@@ -52,6 +52,13 @@ import { getBeginOfOffsetDay, getEndOfOffsetDay } from "@app/utils/time";
 
 @Entity("learner_profiles")
 export class LearnerProfile extends BaseEntity implements ILearnerProfile {
+  constructor(newProfile?: Partial<ILearnerProfile>) {
+    super();
+    if (newProfile) {
+      Object.assign(this, newProfile);
+    }
+  }
+
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
@@ -440,5 +447,10 @@ export class LearnerProfile extends BaseEntity implements ILearnerProfile {
       })
       .setParameter("actionName", ActionNameEnum.DAILY_STREAK)
       .getMany();
+  }
+  public static async createNewProfile(): Promise<ILearnerProfile> {
+    const streak = await new Streak().save();
+    const level = await Level.findOne({ where: { id: 1 } });
+    return this.save({ streak, level });
   }
 }

--- a/libs/database/src/subscribers/account.subscriber.ts
+++ b/libs/database/src/subscribers/account.subscriber.ts
@@ -1,13 +1,12 @@
-import { EntitySubscriberInterface, EventSubscriber, InsertEvent } from "typeorm";
-import { Account, LearnerProfile, Streak } from "../entities";
-import { AccountRoleEnum } from "@app/types/enums";
+import { EntitySubscriberInterface, EventSubscriber } from "typeorm";
+import { Account } from "../entities";
 
 @EventSubscriber()
 export class AccountSubscriber implements EntitySubscriberInterface<Account> {
   listenTo(): typeof Account {
     return Account;
   }
-
+  /*
   async beforeInsert(event: InsertEvent<Account>): Promise<void> {
     const { entity, manager } = event;
     const { role = AccountRoleEnum.LEARNER } = entity;
@@ -26,4 +25,5 @@ export class AccountSubscriber implements EntitySubscriberInterface<Account> {
         break;
     }
   }
+  */
 }

--- a/libs/shared-modules/src/firebase/firebase-auth.service.ts
+++ b/libs/shared-modules/src/firebase/firebase-auth.service.ts
@@ -26,10 +26,10 @@ export class FirebaseAuthService {
     this.app = initializeApp(options);
   }
 
-  async createUserByEmailAndPassword(email: string, password: string) {
+  async createUserByEmailAndPassword(email: string, password: string, emailVerified: boolean) {
     try {
       const auth = getAuth(this.app);
-      return await auth.createUser({ email, password });
+      return await auth.createUser({ email, password, emailVerified });
     } catch (error) {
       if (error.code === "auth/email-already-exists") {
         throw new Error("Email already exists");
@@ -92,6 +92,18 @@ export class FirebaseAuthService {
       const idToken = await this.getIdToken(token);
       const auth = getAuth(this.app);
       return auth.verifyIdToken(idToken);
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async setEmailVerifed(uid: string) {
+    try {
+      const auth = getAuth(this.app);
+      await auth.updateUser(uid, {
+        emailVerified: true,
+      });
     } catch (error) {
       this.logger.error(error);
       throw error;

--- a/libs/shared-modules/src/firebase/firebase-auth.service.ts
+++ b/libs/shared-modules/src/firebase/firebase-auth.service.ts
@@ -29,7 +29,7 @@ export class FirebaseAuthService {
   async createUserByEmailAndPassword(email: string, password: string) {
     try {
       const auth = getAuth(this.app);
-      return await auth.createUser({ email, password, emailVerified: true });
+      return await auth.createUser({ email, password });
     } catch (error) {
       if (error.code === "auth/email-already-exists") {
         throw new Error("Email already exists");

--- a/libs/types/src/constants/workflows-name.constanst.ts
+++ b/libs/types/src/constants/workflows-name.constanst.ts
@@ -1,4 +1,4 @@
-export const SEND_OTP_WORKFLOW = "send-otp-workflow";
+export const RESET_PASSWORD_WORKFLOW = "reset-password-workflow";
 export const REMIND_STREAK_WORKFLOW = "remind-streak-workflow";
 export const REMIND_MISSING_STREAK_WORKFLOW = "remind-missing-streak-workflow";
 export const ANNOUNCE_STREAK_MILESTONE_WORKFLOW = "announce-streak-milestone-workflow";

--- a/libs/types/src/constants/workflows-name.constanst.ts
+++ b/libs/types/src/constants/workflows-name.constanst.ts
@@ -2,3 +2,4 @@ export const SEND_OTP_WORKFLOW = "send-otp-workflow";
 export const REMIND_STREAK_WORKFLOW = "remind-streak-workflow";
 export const REMIND_MISSING_STREAK_WORKFLOW = "remind-missing-streak-workflow";
 export const ANNOUNCE_STREAK_MILESTONE_WORKFLOW = "announce-streak-milestone-workflow";
+export const VERIFY_EMAIL_WORKFLOW = "verify-email-workflow";

--- a/libs/types/src/dtos/accounts/verify-otp.dto.ts
+++ b/libs/types/src/dtos/accounts/verify-otp.dto.ts
@@ -1,4 +1,6 @@
+import { ActionEnum } from "@app/types/enums";
 import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum } from "class-validator";
 
 export class VerifyOtpDto {
   @ApiProperty({ example: "test@exampple.com" })
@@ -6,4 +8,8 @@ export class VerifyOtpDto {
 
   @ApiProperty({ example: "123456" })
   otp: string;
+
+  @ApiProperty({ example: ActionEnum.VERIFY_MAIL })
+  @IsEnum(ActionEnum, { message: "Invalid action name" })
+  action: ActionEnum;
 }

--- a/libs/types/src/enums/action.enum.ts
+++ b/libs/types/src/enums/action.enum.ts
@@ -1,0 +1,4 @@
+export enum ActionEnum {
+  RESET_PASSWORD = "reset-password",
+  VERIFY_MAIL = "verify-mail",
+}

--- a/libs/types/src/enums/index.ts
+++ b/libs/types/src/enums/index.ts
@@ -4,7 +4,7 @@ export * from "./role.enum";
 export * from "./gender.enum";
 export * from "./rank.enum";
 export * from "./profile-mission-progress.enum";
-export * from "./reset-password-action.enum";
+export * from "./action.enum";
 export * from "./bucket-permissions.enum";
 export * from "./bucket-upload-status.enum";
 export * from "./skill.enum";

--- a/libs/types/src/enums/reset-password-action.enum.ts
+++ b/libs/types/src/enums/reset-password-action.enum.ts
@@ -1,3 +1,0 @@
-export enum ResetPasswordActionEnum {
-  RESET_PASSWORD = "reset-password",
-}

--- a/libs/types/src/interfaces/account.interface.ts
+++ b/libs/types/src/interfaces/account.interface.ts
@@ -17,6 +17,6 @@ export interface IAccount {
   updatedAt: Date;
 
   //relationships
-  readonly learnerProfile: ILearnerProfile;
+  learnerProfile: ILearnerProfile;
   readonly avatar: IBucket;
 }

--- a/libs/types/src/interfaces/reset-password-action.interface.ts
+++ b/libs/types/src/interfaces/reset-password-action.interface.ts
@@ -1,6 +1,6 @@
-import { ResetPasswordActionEnum } from "../enums";
+import { ActionEnum } from "../enums";
 
 export interface IResetPasswordAction {
   uid: string;
-  action: ResetPasswordActionEnum;
+  action: ActionEnum.RESET_PASSWORD;
 }


### PR DESCRIPTION
### Basic sign up flow
- Sign up and check that account don't have profile
- Sign in and it said that email not verified
- Get otp with action name is `verify-mail`
- Verify otp with action name is `verify-mail` to get token
- Call API `/auth/profile` to create profile

### With provider
- Sign up and check that account don't have profile
- Sign in and it said that email not verified
- Sign in with provider by that email and check that the profile is created automatically  