### PR TITLE
feat: update new payment logic

### DIFF
--- a/apps/main-api/src/migrations/1737359760106-add_amount_items_columns.ts
+++ b/apps/main-api/src/migrations/1737359760106-add_amount_items_columns.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "typeorm";
+
+export class AddAmountItemsColumns1737359760106 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns("transactions", [
+      new TableColumn({
+        name: "amount",
+        type: "decimal",
+        precision: 10,
+        scale: 2,
+        default: 0,
+      }),
+      new TableColumn({
+        name: "items",
+        type: "jsonb",
+        default: "'[]'",
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn("transactions", "amount");
+    await queryRunner.dropColumn("transactions", "items");
+  }
+}

--- a/apps/main-api/src/modules/payment/payment.controller.ts
+++ b/apps/main-api/src/modules/payment/payment.controller.ts
@@ -18,7 +18,7 @@ import { PaymentService } from "./payment.service";
 import { CreatePaymentLinkDto } from "@app/types/dtos/payment";
 import { CancelPaymentLinkDto } from "@app/types/dtos/payment/cancel-payment-link.dto";
 import { ICurrentUser } from "@app/types/interfaces";
-import { PaginationInterceptor } from "@app/utils/interceptors";
+import { PaginationInterceptor, Transactional } from "@app/utils/interceptors";
 
 @ApiTags("Payment")
 @ApiDefaultResponses()
@@ -30,6 +30,7 @@ export class PaymentController {
 
   @ApiOperation({ summary: "Create payment link" })
   @Post("payment-link")
+  @UseInterceptors(Transactional)
   async createPaymentLink(@CurrentUser() user: ICurrentUser, @Body() data: CreatePaymentLinkDto) {
     return this.paymentService.createPaymentTransaction(data, user.userId);
   }
@@ -37,6 +38,7 @@ export class PaymentController {
   @ApiOperation({ summary: "Get payment link information" })
   @ApiParam({ name: "orderId", type: Number })
   @Get("payment-link/:orderId")
+  @UseInterceptors(Transactional)
   async getPaymentLinkInformation(@Param("orderId") orderId: number) {
     return this.paymentService.getPaymentInformation(orderId);
   }
@@ -44,6 +46,7 @@ export class PaymentController {
   @ApiOperation({ summary: "Cancel payment link" })
   @ApiParam({ name: "orderId", type: Number })
   @Put("payment-link/:orderId")
+  @UseInterceptors(Transactional)
   async cancelPaymentLink(@Param("orderId") orderId: number, @Body() data: CancelPaymentLinkDto) {
     return this.paymentService.cancelPayment(orderId, data);
   }

--- a/apps/main-api/src/modules/payment/payment.controller.ts
+++ b/apps/main-api/src/modules/payment/payment.controller.ts
@@ -65,4 +65,11 @@ export class PaymentController {
   ) {
     return this.paymentService.getTransactionHistory(user.userId, offset, limit);
   }
+
+  @ApiParam({ name: "id", type: Number, required: true })
+  @Get("/transactions/:id")
+  @UseInterceptors(Transactional)
+  async getTransactionDetail(@Param("id", ParseIntPipe) id: number) {
+    return this.paymentService.getPaymentInformation(id);
+  }
 }

--- a/apps/main-api/src/modules/payment/payment.service.ts
+++ b/apps/main-api/src/modules/payment/payment.service.ts
@@ -3,15 +3,15 @@ import { IPayOSRequestLink } from "@app/types/interfaces";
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import { PayOSService } from "./payos.service";
 import { CreatePaymentLinkDto } from "@app/types/dtos/payment";
-import { Transaction } from "@app/database/entities/transaction.entity";
-import { PaymentStatusEnum } from "@app/types/enums";
+import { PaymentCancellationReasonEnum, PaymentStatusEnum } from "@app/types/enums";
 import { ConfigService } from "@nestjs/config";
-import { UnitOfWorkService } from "@app/database";
+import { Transaction, UnitOfWorkService } from "@app/database";
 import { EntityManager } from "typeorm";
+import { EXPIRED_TIME, VN_TIME_ZONE } from "@app/types/constants";
+import { Cron } from "@nestjs/schedule";
 
 @Injectable()
 export class PaymentService {
-  private readonly expireTime = 1000 * 60 * 30; // 30 minutes
   private readonly logger = new Logger(this.constructor.name);
   private readonly paymentRedirectUrl: string;
   constructor(
@@ -34,6 +34,12 @@ export class PaymentService {
             price: 20,
           },
         ];
+
+        const pendingTransactions = await Transaction.getDuplicatedTransactions(userId, items);
+        if (pendingTransactions.length > 0) {
+          this.cancelListOfTransactions(pendingTransactions, PaymentCancellationReasonEnum.DUPLICATE);
+        }
+
         const newTransaction = await manager.save(
           Transaction.create({
             accountId: userId,
@@ -48,7 +54,7 @@ export class PaymentService {
           amount,
           description: "LAPIN - SUBSCRIPTION",
           items,
-          expiredAt: Number(String(new Date(Date.now() + this.expireTime))),
+          expiredAt: Number(String(new Date(Date.now() + EXPIRED_TIME))),
           returnUrl: `${this.paymentRedirectUrl}?success=true`,
           cancelUrl: `${this.paymentRedirectUrl}?canceled=true`,
         };
@@ -108,5 +114,44 @@ export class PaymentService {
       this.logger.error(error);
       throw new BadRequestException(error);
     }
+  }
+
+  @Cron("00 00 * * *", {
+    name: "Revoke expired transactions",
+    timeZone: VN_TIME_ZONE,
+  }) // 12AM every day
+  async revokeExpiredTransactions() {
+    try {
+      const expiredTransactions = await Transaction.getExpiredTransactions();
+      if (expiredTransactions.length > 0) {
+        const { fulfilled, rejected } = await this.cancelListOfTransactions(
+          expiredTransactions,
+          PaymentCancellationReasonEnum.EXPIRED
+        );
+        this.logger.log(`Revoked ${fulfilled} transactions, ${rejected} transactions failed`);
+      }
+    } catch (error) {
+      this.logger.error(error);
+    }
+  }
+
+  private async cancelListOfTransactions(
+    transactions: Transaction[],
+    cancellationReason: PaymentCancellationReasonEnum
+  ) {
+    let rejected = 0;
+    let fulfilled = 0;
+
+    for (const transaction of transactions) {
+      try {
+        await this.cancelPayment(transaction.id, { cancellationReason });
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        fulfilled++;
+      } catch (error) {
+        this.logger.error(error);
+        rejected++;
+      }
+    }
+    return { fulfilled, rejected };
   }
 }

--- a/apps/main-api/src/modules/payment/payment.service.ts
+++ b/apps/main-api/src/modules/payment/payment.service.ts
@@ -72,8 +72,8 @@ export class PaymentService {
         where: { id: orderId },
       });
       if (transaction.status === PaymentStatusEnum.PENDING) {
-        const diff = moment().diff(moment(transaction.createdAt), "minutes");
-        if (diff > 30)
+        const diff = moment().diff(moment(transaction.createdAt), "milliseconds");
+        if (diff > EXPIRED_TIME)
           await this.payOSService.cancelPayOSLink(orderId, {
             cancellationReason: PaymentCancellationReasonEnum.EXPIRED,
           });

--- a/apps/main-api/src/modules/payment/payment.service.ts
+++ b/apps/main-api/src/modules/payment/payment.service.ts
@@ -6,7 +6,6 @@ import { CreatePaymentLinkDto } from "@app/types/dtos/payment";
 import { PaymentCancellationReasonEnum, PaymentStatusEnum } from "@app/types/enums";
 import { ConfigService } from "@nestjs/config";
 import { Transaction, UnitOfWorkService } from "@app/database";
-import { EntityManager } from "typeorm";
 import { EXPIRED_TIME, VN_TIME_ZONE } from "@app/types/constants";
 import { Cron } from "@nestjs/schedule";
 
@@ -23,87 +22,83 @@ export class PaymentService {
   }
 
   async createPaymentTransaction(data: CreatePaymentLinkDto, userId: string) {
-    return this.unitOfWork.doTransactional(async (manager: EntityManager) => {
-      try {
-        const { quantity } = data;
-        const amount = quantity * 20;
-        const items = [
-          {
-            name: data.type,
-            quantity,
-            price: 20,
-          },
-        ];
+    try {
+      const { quantity } = data;
+      const amount = quantity * 20;
+      const items = [
+        {
+          name: data.type,
+          quantity,
+          price: 20,
+        },
+      ];
 
-        const pendingTransactions = await Transaction.getDuplicatedTransactions(userId, items);
-        if (pendingTransactions.length > 0) {
-          this.cancelListOfTransactions(pendingTransactions, PaymentCancellationReasonEnum.DUPLICATE);
-        }
-
-        const newTransaction = await manager.save(
-          Transaction.create({
-            accountId: userId,
-            status: PaymentStatusEnum.PENDING,
-            amount,
-            items,
-          })
-        );
-
-        const request: IPayOSRequestLink = {
-          orderCode: newTransaction.id,
-          amount,
-          description: "LAPIN - SUBSCRIPTION",
-          items,
-          expiredAt: Number(String(new Date(Date.now() + EXPIRED_TIME))),
-          returnUrl: `${this.paymentRedirectUrl}?success=true`,
-          cancelUrl: `${this.paymentRedirectUrl}?canceled=true`,
-        };
-
-        return this.payOSService.createPaymentLink(request, manager);
-      } catch (error) {
-        this.logger.error(error);
-        throw error;
+      const pendingTransactions = await Transaction.getDuplicatedTransactions(userId, items);
+      if (pendingTransactions.length > 0) {
+        this.cancelListOfTransactions(pendingTransactions, PaymentCancellationReasonEnum.DUPLICATED);
       }
-    });
+
+      const newTransaction = await this.unitOfWork.getManager().save(
+        Transaction.create({
+          accountId: userId,
+          status: PaymentStatusEnum.PENDING,
+          amount,
+          items,
+        })
+      );
+
+      const request: IPayOSRequestLink = {
+        orderCode: newTransaction.id,
+        amount,
+        description: "LAPIN - SUBSCRIPTION",
+        items,
+        expiredAt: Number(String(new Date(Date.now() + EXPIRED_TIME))),
+        returnUrl: `${this.paymentRedirectUrl}?success=true`,
+        cancelUrl: `${this.paymentRedirectUrl}?canceled=true`,
+      };
+
+      return this.payOSService.createPaymentLink(request);
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
   }
 
   async getPaymentInformation(orderId: number) {
-    return this.unitOfWork.doTransactional(async (manager: EntityManager) => {
-      try {
-        const transaction = await Transaction.findOne({
-          where: { id: orderId },
-        });
-        const information = await this.payOSService.getPaymentLinkInformation(orderId);
-        const { status } = information;
-        if (transaction) {
-          transaction.status = status.toLowerCase() as PaymentStatusEnum;
-          await manager.save(transaction);
-        }
-        return information;
-      } catch (error) {
-        this.logger.error(error);
-        throw error;
+    try {
+      const manager = this.unitOfWork.getManager();
+      const transaction = await manager.findOne(Transaction, {
+        where: { id: orderId },
+      });
+      const information = await this.payOSService.getPaymentLinkInformation(orderId);
+      const { status } = information;
+      if (transaction) {
+        transaction.status = status.toLowerCase() as PaymentStatusEnum;
+        await manager.save(transaction);
       }
-    });
+      return information;
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
   }
 
   async cancelPayment(orderId: number, { cancellationReason }: CancelPaymentLinkDto) {
-    return this.unitOfWork.doTransactional(async (manager: EntityManager) => {
-      try {
-        const information = await this.payOSService.cancelPayOSLink(orderId, { cancellationReason });
-        const transaction = await Transaction.findOne({
-          where: { id: orderId },
-        });
-        if (transaction) {
-          transaction.status = PaymentStatusEnum.CANCELLED;
-          await manager.save(transaction);
-        }
-        return information;
-      } catch (error) {
-        this.logger.error(error);
-        throw error;
+    try {
+      const manager = this.unitOfWork.getManager();
+      const information = await this.payOSService.cancelPayOSLink(orderId, { cancellationReason });
+      const transaction = await manager.findOne(Transaction, {
+        where: { id: orderId },
+      });
+      if (transaction) {
+        transaction.status = PaymentStatusEnum.CANCELLED;
+        await manager.save(transaction);
       }
-    });
+      return information;
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
   }
 
   async getTransactionHistory(accountId: string, offset: number, limit: number) {

--- a/apps/main-api/src/modules/payment/payos.service.ts
+++ b/apps/main-api/src/modules/payment/payos.service.ts
@@ -1,7 +1,7 @@
 import { OK_RESPONSE, PAYOS_INSTANCE } from "@app/types/constants";
-import { PayOSTransaction, Transaction, UnitOfWorkService } from "@app/database";
+import { LearnerProfile, PayOSTransaction, Transaction, UnitOfWorkService } from "@app/database";
 import { CancelPaymentLinkDto } from "@app/types/dtos/payment/cancel-payment-link.dto";
-import { PaymentStatusEnum } from "@app/types/enums";
+import { PaymentStatusEnum, PaymentTypeEnum } from "@app/types/enums";
 import { IPayOSRequestLink } from "@app/types/interfaces";
 import { IPayOSWebhook } from "@app/types/interfaces/payment/payos-webhook.interface";
 import { Inject, Injectable, Logger } from "@nestjs/common";
@@ -122,10 +122,26 @@ export class PayOSService {
       }
 
       // Update system transaction status
-      const systemTransaction = await manager.findOne(Transaction, { where: { id: orderCode } });
+      const systemTransaction = await manager.findOne(Transaction, {
+        where: { id: orderCode },
+        relations: {
+          account: true,
+        },
+      });
       if (systemTransaction) {
         systemTransaction.status = this.SUCCESS_CODE == code ? PaymentStatusEnum.PAID : PaymentStatusEnum.ERROR;
         await manager.save(systemTransaction);
+
+        if (systemTransaction.status === PaymentStatusEnum.PAID) {
+          const learnerProfile = await manager.findOneOrFail(LearnerProfile, {
+            where: { id: systemTransaction.account.learnerProfileId },
+          });
+
+          for (const item of systemTransaction.items) {
+            if (item.name === PaymentTypeEnum.CARROTS) learnerProfile.carrots += item.quantity;
+          }
+          await manager.save(learnerProfile);
+        }
       }
 
       return OK_RESPONSE;

--- a/libs/database/src/entities/payos-transaction.entity.ts
+++ b/libs/database/src/entities/payos-transaction.entity.ts
@@ -1,5 +1,5 @@
 import { PaymentStatusEnum } from "@app/types/enums";
-import { IPayOSTransaction } from "@app/types/interfaces/payment";
+import { IPayOSTransaction } from "@app/types/interfaces";
 import {
   Entity,
   BaseEntity,

--- a/libs/database/src/entities/transaction.entity.ts
+++ b/libs/database/src/entities/transaction.entity.ts
@@ -94,7 +94,7 @@ export class Transaction extends BaseEntity implements ITransaction {
     return this.createQueryBuilder("transaction")
       .where("transaction.accountId = :accountId", { accountId })
       .andWhere("transaction.status = :status", { status: PaymentStatusEnum.PENDING })
-      .andWhere("transaction.items @> :items", { items: JSON.stringify(items) })
+      .andWhere(":items @> transaction.items", { items: JSON.stringify(items) })
       .getMany();
   }
 }

--- a/libs/database/src/entities/transaction.entity.ts
+++ b/libs/database/src/entities/transaction.entity.ts
@@ -13,6 +13,7 @@ import {
 } from "typeorm";
 import { Account } from "./account.entity";
 import { PayOSTransaction } from "./payos-transaction.entity";
+import { IItemTransaction } from "@app/types/interfaces/payment/item-transaction.interface";
 
 @Entity("transactions")
 export class Transaction extends BaseEntity implements ITransaction {
@@ -28,6 +29,17 @@ export class Transaction extends BaseEntity implements ITransaction {
     default: PaymentStatusEnum.PENDING,
   })
   status: PaymentStatusEnum; // e.g., paid, canceled, pending
+
+  @Column({
+    type: "decimal",
+    precision: 10,
+    scale: 2,
+    default: 0,
+  })
+  amount: number;
+
+  @Column({ type: "jsonb", nullable: false, default: [] }) // If null, it's a subscription, donate, or testing
+  items: IItemTransaction[]; // Items in the transaction
 
   @CreateDateColumn({
     name: "created_at",

--- a/libs/database/src/unit-of-work.service.ts
+++ b/libs/database/src/unit-of-work.service.ts
@@ -1,24 +1,35 @@
-import { Injectable, Scope } from "@nestjs/common";
+import { TRANSACTION_MANAGER_STORAGE } from "@app/types/constants";
+import { CallHandler, Injectable, Logger } from "@nestjs/common";
 import { InjectDataSource } from "@nestjs/typeorm";
+import { AsyncLocalStorage } from "async_hooks";
 import { DataSource, EntityManager } from "typeorm";
+import { firstValueFrom, Observable, of } from "rxjs";
 
-@Injectable({
-  scope: Scope.REQUEST,
-})
+@Injectable()
 export class UnitOfWorkService {
-  private manager: EntityManager;
+  private readonly asyncLocalStorage: AsyncLocalStorage<any>;
+  private readonly logger = new Logger(UnitOfWorkService.name);
   constructor(@InjectDataSource() private readonly dataSource: DataSource) {
-    this.manager = this.dataSource.manager;
+    this.logger.log("Load unit of work");
+    this.asyncLocalStorage = new AsyncLocalStorage();
   }
 
-  getManager() {
-    return this.manager;
+  getManager(): EntityManager {
+    const storage = this.asyncLocalStorage.getStore();
+    if (storage && storage.has(TRANSACTION_MANAGER_STORAGE)) {
+      return storage.get(TRANSACTION_MANAGER_STORAGE);
+    }
+    return this.dataSource.createEntityManager();
   }
 
-  async doTransactional<T>(fn: any): Promise<T> {
+  async doTransactional(fn: CallHandler): Promise<Observable<any>> {
     return await this.dataSource.transaction(async (manager) => {
-      this.manager = manager;
-      return fn(manager);
+      let response: Observable<any>;
+      await this.asyncLocalStorage.run(new Map<string, EntityManager>(), async () => {
+        this.asyncLocalStorage.getStore().set(TRANSACTION_MANAGER_STORAGE, manager);
+        response = await firstValueFrom(fn.handle());
+      });
+      return of(response);
     });
   }
 }

--- a/libs/types/src/constants/index.ts
+++ b/libs/types/src/constants/index.ts
@@ -14,3 +14,4 @@ export * from "./payment-provider.constant";
 export * from "./firebase-provider.constant";
 export * from "./speaking-evaluation.constant";
 export * from "./payment-config.constant";
+export * from "./transaction-manager-storage.constant";

--- a/libs/types/src/constants/index.ts
+++ b/libs/types/src/constants/index.ts
@@ -13,3 +13,4 @@ export * from "./provider-name.constant";
 export * from "./payment-provider.constant";
 export * from "./firebase-provider.constant";
 export * from "./speaking-evaluation.constant";
+export * from "./payment-config.constant";

--- a/libs/types/src/constants/payment-config.constant.ts
+++ b/libs/types/src/constants/payment-config.constant.ts
@@ -1,0 +1,1 @@
+export const EXPIRED_TIME = 1000 * 60 * 60 * 12; // 12 hours

--- a/libs/types/src/constants/transaction-manager-storage.constant.ts
+++ b/libs/types/src/constants/transaction-manager-storage.constant.ts
@@ -1,0 +1,1 @@
+export const TRANSACTION_MANAGER_STORAGE = "transaction_manager_storage";

--- a/libs/types/src/enums/index.ts
+++ b/libs/types/src/enums/index.ts
@@ -21,5 +21,4 @@ export * from "./test-session-mode.enum";
 export * from "./test-session-status.enum";
 export * from "./answer-type.enum";
 export * from "./genai-part.enum";
-export * from "./payment-type.enum";
 export * from "./payment-status.enum";

--- a/libs/types/src/enums/payment-status.enum.ts
+++ b/libs/types/src/enums/payment-status.enum.ts
@@ -5,3 +5,12 @@ export enum PaymentStatusEnum {
   ERROR = "error",
   UNDERPAID = "underpaid",
 }
+
+export enum PaymentTypeEnum {
+  CARROTS = "carrots",
+}
+
+export enum PaymentCancellationReasonEnum {
+  DUPLICATE = "DUPLICATE",
+  EXPIRED = "EXPIRED",
+}

--- a/libs/types/src/enums/payment-status.enum.ts
+++ b/libs/types/src/enums/payment-status.enum.ts
@@ -11,6 +11,6 @@ export enum PaymentTypeEnum {
 }
 
 export enum PaymentCancellationReasonEnum {
-  DUPLICATE = "DUPLICATE",
+  DUPLICATED = "DUPLICATED",
   EXPIRED = "EXPIRED",
 }

--- a/libs/types/src/enums/payment-type.enum.ts
+++ b/libs/types/src/enums/payment-type.enum.ts
@@ -1,3 +1,0 @@
-export enum PaymentTypeEnum {
-  CARROTS = "carrots",
-}

--- a/libs/types/src/interfaces/payment/index.ts
+++ b/libs/types/src/interfaces/payment/index.ts
@@ -1,3 +1,4 @@
 export * from "./payos-request-link.interface";
 export * from "./transaction.interface";
 export * from "./payos-transaction.interface";
+export * from "./item-transaction.interface";

--- a/libs/types/src/interfaces/payment/item-transaction.interface.ts
+++ b/libs/types/src/interfaces/payment/item-transaction.interface.ts
@@ -1,0 +1,7 @@
+import { PaymentTypeEnum } from "@app/types/enums";
+
+export interface IItemTransaction {
+  name: PaymentTypeEnum;
+  price: number;
+  quantity: number;
+}

--- a/libs/utils/src/interceptors/index.ts
+++ b/libs/utils/src/interceptors/index.ts
@@ -3,3 +3,4 @@ export * from "./transform-response.interceptor";
 export * from "./pagination.interceptor";
 export * from "./parse-form-data.interceptor";
 export * from "./logger-request.interceptor";
+export * from "./transactional.interceptor";

--- a/libs/utils/src/interceptors/transactional.interceptor.ts
+++ b/libs/utils/src/interceptors/transactional.interceptor.ts
@@ -1,0 +1,12 @@
+import { UnitOfWorkService } from "@app/database";
+import { CallHandler, ExecutionContext, NestInterceptor, Injectable, Scope } from "@nestjs/common";
+import { Observable } from "rxjs";
+
+@Injectable({ scope: Scope.REQUEST })
+export class Transactional implements NestInterceptor {
+  constructor(private readonly unitOfWork: UnitOfWorkService) {}
+
+  async intercept(_: ExecutionContext, next: CallHandler<any>): Promise<Observable<any>> {
+    return this.unitOfWork.doTransactional(next);
+  }
+}


### PR DESCRIPTION
- _Old: Only when webhook receives data, a new record is created_ -> Create record when a new transaction is created and update data when cancelled, it helps store the metadata because payOS doesn't return us QR code and payment link in its GET method
- Introduce a logic to revoke expired transaction:
   - Change from 30 mins to 12 hours expiration time
   - Every midnight, check if there are any transaction created more than 12 hours ago, if yes, revoked them (POST cancel)
   - When user creates a new payment link, check if there are any transaction pending with the same items/bill, if yes, cancel them with DUPLICATED reason
 - 2 new columns to easily retrieve data for transaction list
<img width="876" alt="image" src="https://github.com/user-attachments/assets/f26a37d6-41ea-441d-a925-b6dc5927a3b6" />
<img width="876" alt="image" src="https://github.com/user-attachments/assets/2b846266-d5a7-410d-9296-8701135c14e3" />
