### PR TITLE
feat(LAP-729): latest inprogress endpoint

### DIFF
--- a/apps/main-api/src/modules/simulated-test/session.controller.ts
+++ b/apps/main-api/src/modules/simulated-test/session.controller.ts
@@ -21,6 +21,7 @@ import { FilesInterceptor } from "@nestjs/platform-express";
 import { plainToInstance } from "class-transformer";
 import { SessionService } from "./session.service";
 import { SkillEnum } from "@app/types/enums";
+import { LatestInprogressSessionDto } from "@app/types/response-dtos";
 
 @ApiTags("Simulated tests")
 @ApiDefaultResponses()
@@ -44,6 +45,7 @@ export class SessionController {
   @ApiOperation({ summary: "Get a latest in-progress session" })
   @ApiQuery({ name: "skill", required: false, enum: SkillEnum })
   @ApiQuery({ name: "collectionId", required: false, type: Number })
+  @ApiResponse({ type: LatestInprogressSessionDto, status: 200 })
   @Get("simulated-tests/sessions/latest")
   async getLatestInprogressSession(
     @CurrentUser() user: ICurrentUser,

--- a/apps/main-api/src/modules/simulated-test/session.service.ts
+++ b/apps/main-api/src/modules/simulated-test/session.service.ts
@@ -1,0 +1,22 @@
+import { SkillTestSession } from "@app/database";
+import { ICurrentUser } from "@app/types/interfaces";
+import { BadRequestException, Injectable, Logger } from "@nestjs/common";
+import { SkillEnum } from "@app/types/enums";
+import { OK_RESPONSE } from "@app/types/constants";
+
+@Injectable()
+export class SessionService {
+  private readonly logger = new Logger(this.constructor.name);
+  constructor() {}
+
+  async getLatestInprogressSession(learner: ICurrentUser, skill?: SkillEnum, collectionId?: number) {
+    try {
+      const data = await SkillTestSession.getLatestInprogressSessionWithFilter(learner.profileId, skill, collectionId);
+      if (!data) return OK_RESPONSE;
+      return data;
+    } catch (error) {
+      this.logger.error(error);
+      throw new BadRequestException(error);
+    }
+  }
+}

--- a/apps/main-api/src/modules/simulated-test/session.service.ts
+++ b/apps/main-api/src/modules/simulated-test/session.service.ts
@@ -3,17 +3,31 @@ import { ICurrentUser } from "@app/types/interfaces";
 import { BadRequestException, Injectable, Logger } from "@nestjs/common";
 import { SkillEnum } from "@app/types/enums";
 import { OK_RESPONSE } from "@app/types/constants";
+import { LatestInprogressSessionDto } from "@app/types/response-dtos";
 
 @Injectable()
 export class SessionService {
   private readonly logger = new Logger(this.constructor.name);
   constructor() {}
 
-  async getLatestInprogressSession(learner: ICurrentUser, skill?: SkillEnum, collectionId?: number) {
+  async getLatestInprogressSession(
+    learner: ICurrentUser,
+    skill?: SkillEnum,
+    collectionId?: number
+  ): Promise<string | LatestInprogressSessionDto> {
     try {
       const data = await SkillTestSession.getLatestInprogressSessionWithFilter(learner.profileId, skill, collectionId);
       if (!data) return OK_RESPONSE;
-      return data;
+      return {
+        sessionId: data.id,
+        mode: data.mode,
+        status: data.status,
+        parts: data.parts,
+        skillTestId: data.skillTestId,
+        skill: data.skillTest.skill,
+        testName: data.skillTest.simulatedIeltsTest.testName,
+        testCollectionName: data.skillTest.simulatedIeltsTest.testCollection.name,
+      };
     } catch (error) {
       this.logger.error(error);
       throw new BadRequestException(error);

--- a/apps/main-api/src/modules/simulated-test/simulated-test-report.controller.ts
+++ b/apps/main-api/src/modules/simulated-test/simulated-test-report.controller.ts
@@ -33,10 +33,4 @@ export class SimulatedTestReportController {
   ) {
     return this.simulatedTestService.getQuestionTypeAccuracy(learner, skill);
   }
-
-  @ApiOperation({ summary: "Get average band scores of 4 skills all time" })
-  @Get("simulated-tests/report")
-  async getBandScoreReport(@CurrentUser() learner: ICurrentUser) {
-    return this.simulatedTestService.getBandScoreReport(learner);
-  }
 }

--- a/apps/main-api/src/modules/simulated-test/simulated-test-report.controller.ts
+++ b/apps/main-api/src/modules/simulated-test/simulated-test-report.controller.ts
@@ -33,4 +33,10 @@ export class SimulatedTestReportController {
   ) {
     return this.simulatedTestService.getQuestionTypeAccuracy(learner, skill);
   }
+
+  @ApiOperation({ summary: "Get average band scores of 4 skills all time" })
+  @Get("simulated-tests/report")
+  async getBandScoreReport(@CurrentUser() learner: ICurrentUser) {
+    return this.simulatedTestService.getBandScoreReport(learner);
+  }
 }

--- a/apps/main-api/src/modules/simulated-test/simulated-test.controller.ts
+++ b/apps/main-api/src/modules/simulated-test/simulated-test.controller.ts
@@ -80,6 +80,12 @@ export class SimulatedTestController {
     return this.simulatedTestService.getSessionHistory(learner, offset, limit);
   }
 
+  @ApiOperation({ summary: "Get average band scores of 4 skills all time" })
+  @Get("simulated-tests/report")
+  async getBandScoreReport(@CurrentUser() learner: ICurrentUser) {
+    return this.simulatedTestService.getBandScoreReport(learner);
+  }
+
   @ApiOperation({ summary: "Get session history of a simulated test" })
   @ApiQuery({ name: "offset", type: Number, required: false })
   @ApiQuery({ name: "limit", type: Number, required: false })

--- a/apps/main-api/src/modules/simulated-test/simulated-test.controller.ts
+++ b/apps/main-api/src/modules/simulated-test/simulated-test.controller.ts
@@ -42,6 +42,7 @@ export class SimulatedTestController {
     return this.simulatedTestService.getCollectionsWithSimulatedTest(offset, limit, keyword, user.profileId);
   }
 
+  @ApiOperation({ summary: "Get all STs in a collection" })
   @ApiParam({ name: "id", type: Number, required: true })
   @ApiQuery({ name: "offset", type: Number, required: false })
   @ApiQuery({ name: "limit", type: Number, required: false })
@@ -57,6 +58,16 @@ export class SimulatedTestController {
     return this.simulatedTestService.getSimulatedTestsInCollections(collectionId, offset, limit, user.profileId);
   }
 
+  @ApiOperation({
+    summary: "Get information of a ST collection, to render collection detail page",
+  })
+  @ApiParam({ name: "id", type: Number, required: true })
+  @Get("collections/:id")
+  async getCollectionInfo(@Param("id", ParseIntPipe) collectionId: number) {
+    return this.simulatedTestService.getCollectionInformation(collectionId);
+  }
+
+  @ApiOperation({ summary: "Get session history (all)" })
   @ApiQuery({ name: "offset", type: Number, required: false })
   @ApiQuery({ name: "limit", type: Number, required: false })
   @Get("simulated-tests/sessions")
@@ -69,12 +80,7 @@ export class SimulatedTestController {
     return this.simulatedTestService.getSessionHistory(learner, offset, limit);
   }
 
-  @ApiOperation({ summary: "Get average band scores of 4 skills all time" })
-  @Get("simulated-tests/report")
-  async getBandScoreReport(@CurrentUser() learner: ICurrentUser) {
-    return this.simulatedTestService.getBandScoreReport(learner);
-  }
-
+  @ApiOperation({ summary: "Get session history of a simulated test" })
   @ApiQuery({ name: "offset", type: Number, required: false })
   @ApiQuery({ name: "limit", type: Number, required: false })
   @ApiQuery({ name: "skill", enum: SkillEnum, required: false })
@@ -90,6 +96,7 @@ export class SimulatedTestController {
     return this.simulatedTestService.getSessionHistory(learner, offset, limit, { simulatedTestId, skill });
   }
 
+  @ApiOperation({ summary: "Get simulated test information, include all skill tests inside" })
   @ApiParam({ name: "id", type: Number, required: true })
   @ApiResponse({ type: SimulatedIeltsTestDetailDto })
   @Get("simulated-tests/:id")
@@ -97,6 +104,7 @@ export class SimulatedTestController {
     return this.simulatedTestService.getSimulatedTestInfo(testId);
   }
 
+  @ApiOperation({ summary: "Get a skill test content to render question to learner" })
   @ApiParam({ name: "id", type: Number, required: true })
   @ApiQuery({ name: "part", type: Number, required: true })
   @Get("skill-tests/:id")

--- a/apps/main-api/src/modules/simulated-test/simulated-test.module.ts
+++ b/apps/main-api/src/modules/simulated-test/simulated-test.module.ts
@@ -8,6 +8,7 @@ import { EVALUATE_SPEAKING_QUEUE, EVALUATE_WRITING_QUEUE } from "@app/types/cons
 import { RedisModule } from "@app/shared-modules/redis";
 import { SimulatedTestReportController } from "./simulated-test-report.controller";
 import { SessionController } from "./session.controller";
+import { SessionService } from "./session.service";
 
 @Module({
   imports: [
@@ -24,7 +25,7 @@ import { SessionController } from "./session.controller";
     BucketModule,
     RedisModule,
   ],
-  providers: [SimulatedTestService],
+  providers: [SimulatedTestService, SessionService],
   controllers: [SimulatedTestController, SimulatedTestReportController, SessionController],
 })
 export class SimulatedTestModule {}

--- a/apps/main-api/src/modules/simulated-test/simulated-test.service.ts
+++ b/apps/main-api/src/modules/simulated-test/simulated-test.service.ts
@@ -69,6 +69,25 @@ export class SimulatedTestService {
     }
   }
 
+  async getCollectionInformation(collectionId: number) {
+    try {
+      const data = await TestCollection.findOneOrFail({
+        where: { id: collectionId },
+        relations: {
+          thumbnail: true,
+        },
+      });
+      this.logger.log(data);
+      return {
+        ...data,
+        thumbnail: await this.bucketService.getPresignedDownloadUrlForAfterLoad(data.thumbnail),
+      };
+    } catch (error) {
+      this.logger.error(error);
+      throw new BadRequestException(error);
+    }
+  }
+
   async getSimulatedTestsInCollections(collectionId: number, offset: number, limit: number, profileId: string) {
     try {
       const items = await SimulatedIeltsTest.getSimulatedTestInCollections(collectionId, offset, limit, profileId);

--- a/libs/database/src/entities/test-sessions.entity.ts
+++ b/libs/database/src/entities/test-sessions.entity.ts
@@ -219,4 +219,23 @@ export class SkillTestSession extends BaseEntity {
 
     return query.getRawMany();
   }
+
+  static async getLatestInprogressSessionWithFilter(learnerId: string, skill?: SkillEnum, collectionId?: number) {
+    const query = this.createQueryBuilder("session")
+      .select(["session.id", "session.responses", "session.mode", "session.status", "session.parts"])
+      .leftJoin("session.skillTest", "skillTest")
+      .addSelect(["skillTest.id", "skillTest.skill", "skillTest.testId"])
+      .leftJoin("skillTest.simulatedIeltsTest", "simulatedIeltsTest")
+      .where("session.learnerProfileId = :learnerId", { learnerId })
+      .andWhere("session.status = :status", { status: TestSessionStatusEnum.IN_PROGRESS });
+    if (skill) {
+      query.andWhere("skillTest.skill = :skill", { skill });
+    }
+    if (collectionId) {
+      query.andWhere("simulatedIeltsTest.collectionId = :collectionId", { collectionId });
+    }
+    query.orderBy("session.id", "DESC");
+
+    return query.getOne();
+  }
 }

--- a/libs/database/src/entities/test-sessions.entity.ts
+++ b/libs/database/src/entities/test-sessions.entity.ts
@@ -222,10 +222,13 @@ export class SkillTestSession extends BaseEntity {
 
   static async getLatestInprogressSessionWithFilter(learnerId: string, skill?: SkillEnum, collectionId?: number) {
     const query = this.createQueryBuilder("session")
-      .select(["session.id", "session.responses", "session.mode", "session.status", "session.parts"])
+      .select(["session.id", "session.mode", "session.status", "session.parts"])
       .leftJoin("session.skillTest", "skillTest")
       .addSelect(["skillTest.id", "skillTest.skill", "skillTest.testId"])
       .leftJoin("skillTest.simulatedIeltsTest", "simulatedIeltsTest")
+      .addSelect(["simulatedIeltsTest.testName"])
+      .leftJoin("simulatedIeltsTest.testCollection", "testCollection")
+      .addSelect(["testCollection.name"])
       .where("session.learnerProfileId = :learnerId", { learnerId })
       .andWhere("session.status = :status", { status: TestSessionStatusEnum.IN_PROGRESS });
     if (skill) {

--- a/libs/types/src/response-dtos/simulated-test/index.ts
+++ b/libs/types/src/response-dtos/simulated-test/index.ts
@@ -1,2 +1,3 @@
 export * from "./test-collection-response.dto";
 export * from "./simulated-ielts-test-detail.dto";
+export * from "./latest-inprogress-session.dto";

--- a/libs/types/src/response-dtos/simulated-test/latest-inprogress-session.dto.ts
+++ b/libs/types/src/response-dtos/simulated-test/latest-inprogress-session.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { SkillEnum, TestSessionStatusEnum } from "@app/types/enums";
+
+export class LatestInprogressSessionDto {
+  @ApiProperty()
+  sessionId: number;
+
+  @ApiProperty()
+  mode: string;
+
+  @ApiProperty({ enum: TestSessionStatusEnum })
+  status: TestSessionStatusEnum;
+
+  @ApiProperty({ isArray: true, type: Number })
+  parts: number[];
+
+  @ApiProperty()
+  skillTestId: number;
+
+  @ApiProperty({ enum: SkillEnum })
+  skill: SkillEnum;
+
+  @ApiProperty()
+  testName: string;
+
+  @ApiProperty()
+  testCollectionName: string;
+}


### PR DESCRIPTION
Here is the ticket: https://datn.atlassian.net/browse/LAP-654
I introduce 2 endpoint:
- Collection detail, don't know why we miss this :)), right now FE retrieve data by searching the GET all enpoint
- GET latest session, by collectionid, sort by skill