### PR TITLE
style: return statuses in session history endpoint

### DIFF
--- a/libs/database/src/entities/test-sessions.entity.ts
+++ b/libs/database/src/entities/test-sessions.entity.ts
@@ -156,6 +156,13 @@ export class SkillTestSession extends BaseEntity {
     simulatedTestId?: number,
     skill?: SkillEnum
   ) {
+    const finishedStatuses = [
+      TestSessionStatusEnum.FINISHED,
+      TestSessionStatusEnum.EVALUATION_FAILED,
+      TestSessionStatusEnum.NOT_EVALUATED,
+      TestSessionStatusEnum.IN_EVALUATING,
+    ];
+
     const query = this.createQueryBuilder("session")
       .select([
         "session.id",
@@ -164,13 +171,14 @@ export class SkillTestSession extends BaseEntity {
         "session.elapsedTime",
         "session.results",
         "session.mode",
+        "session.status",
       ])
       .leftJoin("session.skillTest", "skillTest")
       .addSelect(["skillTest.id", "skillTest.skill"])
       .leftJoin("skillTest.simulatedIeltsTest", "test")
       .addSelect(["test.testName"])
       .where("session.learner_profile_id = :learnerId", { learnerId })
-      .andWhere("session.status = :status", { status: TestSessionStatusEnum.FINISHED })
+      .andWhere("session.status IN (:...statuses)", { statuses: finishedStatuses })
       .orderBy("session.createdAt", "DESC");
 
     if (simulatedTestId) {


### PR DESCRIPTION
<img width="847" alt="image" src="https://github.com/user-attachments/assets/f91fbb84-506b-4a36-a978-b7d98d77afe8" />
Updated design, user need to know if a test is evaluated or not, failed or succeeded. In session history table, the column "Kết quả" is updated, when status is not evaluated, failed or in evaluating, it render a badge instead of "--"
<img width="847" alt="image" src="https://github.com/user-attachments/assets/e8abc8d7-7857-4c07-b5c5-c752326d5a0f" />