### PR TITLE
feat(lap-759): handle logic to complete lower band score lesson of question types

### DIFF
--- a/apps/main-api/src/modules/daily-lesson/daily-lesson.controller.ts
+++ b/apps/main-api/src/modules/daily-lesson/daily-lesson.controller.ts
@@ -1,8 +1,19 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Post, Query, UseGuards, ValidationPipe } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseEnumPipe,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards,
+  ValidationPipe,
+} from "@nestjs/common";
 import { DailyLessonService } from "./daily-lesson.service";
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { CompleteLessonDto, QueryQuestionTypesDto } from "@app/types/dtos";
-import { AccountRoleEnum, SkillEnum } from "@app/types/enums";
+import { AccountRoleEnum, BandScoreEnum, SkillEnum } from "@app/types/enums";
 import { FirebaseJwtAuthGuard } from "../../guards";
 import { ApiDefaultResponses, CurrentUser, Roles } from "../../decorators";
 import { ICurrentUser } from "@app/types/interfaces";
@@ -30,8 +41,18 @@ export class DailyLessonController {
   @ApiParam({ name: "id", description: "Question type id", type: Number })
   @ApiDefaultResponses()
   @Get("question-types/:id/lessons")
-  async getLessonsByQuestionType(@Param("id", ParseIntPipe) id: number, @CurrentUser() learner: ICurrentUser) {
-    return this.dailyLessonService.getLessonsInQuestionTypeOfLearner(id, learner.profileId);
+  async getLessonsByQuestionType(
+    @Param("id", ParseIntPipe) id: number,
+    @Query("band", new ParseEnumPipe(BandScoreEnum)) band: BandScoreEnum,
+    @CurrentUser() learner: ICurrentUser
+  ) {
+    return this.dailyLessonService.getLessonsInQuestionTypeOfLearner(id, learner.profileId, band);
+  }
+
+  @ApiOperation({ summary: "Get list band score base on current user band score of question type" })
+  @Get("question-types/:id/band-scores")
+  async getListBandScore(@Param("id", ParseIntPipe) id: number, @CurrentUser() learner: ICurrentUser) {
+    return this.dailyLessonService.getListLessonBandScore(id, learner.profileId);
   }
 
   @ApiOperation({ summary: "Complete a lesson" })

--- a/apps/main-api/src/modules/daily-lesson/daily-lesson.controller.ts
+++ b/apps/main-api/src/modules/daily-lesson/daily-lesson.controller.ts
@@ -1,15 +1,4 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Param,
-  ParseEnumPipe,
-  ParseIntPipe,
-  Post,
-  Query,
-  UseGuards,
-  ValidationPipe,
-} from "@nestjs/common";
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Query, UseGuards, ValidationPipe } from "@nestjs/common";
 import { DailyLessonService } from "./daily-lesson.service";
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { CompleteLessonDto, QueryQuestionTypesDto } from "@app/types/dtos";
@@ -43,8 +32,8 @@ export class DailyLessonController {
   @Get("question-types/:id/lessons")
   async getLessonsByQuestionType(
     @Param("id", ParseIntPipe) id: number,
-    @Query("band", new ParseEnumPipe(BandScoreEnum)) band: BandScoreEnum,
-    @CurrentUser() learner: ICurrentUser
+    @CurrentUser() learner: ICurrentUser,
+    @Query("band") band?: BandScoreEnum
   ) {
     return this.dailyLessonService.getLessonsInQuestionTypeOfLearner(id, learner.profileId, band);
   }

--- a/apps/main-api/src/modules/daily-lesson/daily-lesson.service.ts
+++ b/apps/main-api/src/modules/daily-lesson/daily-lesson.service.ts
@@ -69,7 +69,7 @@ export class DailyLessonService {
         if (!band) {
           where.bandScore = currentProcess.bandScore;
         } else if (BandScoreOrder.indexOf(currentProcess.bandScore) < BandScoreOrder.indexOf(band)) {
-          throw new BadRequestException("This band is unavailable for you");
+          throw new BadRequestException("The lesson of this band score level is unavailable to you");
         } else {
           where.bandScore = band;
         }
@@ -80,16 +80,22 @@ export class DailyLessonService {
         order: { order: "ASC" },
       });
 
+      let totalLearningDuration = 0;
       const lessonsProcess = lessons.map((lesson) => {
         lesson.id === currentProcess?.currentLessonId ? (lesson["isCurrent"] = true) : (lesson["isCurrent"] = false);
         const lessonProcess = currentProcess?.xp.find((l) => l.lessonId === lesson.id);
-        lesson["xp"] = !_.isNil(lessonProcess) ? lessonProcess.xp : 0;
+        if (!_.isNil(lessonProcess)) {
+          lesson["xp"] = lessonProcess.xp;
+          totalLearningDuration += lessonProcess.duration;
+        } else {
+          lesson["xp"] = 0;
+        }
         return lesson;
       });
 
       return {
         lessons: lessonsProcess,
-        totalLearningDuration: currentProcess?.xp.reduce((acc, cur) => acc + cur.duration, 0) || 0,
+        totalLearningDuration,
       };
     } catch (error) {
       this.logger.error(error);

--- a/libs/database/src/entities/learner-profile.entity.ts
+++ b/libs/database/src/entities/learner-profile.entity.ts
@@ -220,7 +220,7 @@ export class LearnerProfile extends BaseEntity implements ILearnerProfile {
     questionTypeId: number
   ): Promise<boolean> {
     let currentQuestionTypeProcess = this.lessonProcesses.find(
-      (lessonProcess) => lessonProcess.questionType.id === questionTypeId
+      (lessonProcess) => lessonProcess.questionTypeId === questionTypeId
     );
 
     if (currentQuestionTypeProcess === undefined) {

--- a/libs/database/src/entities/learner-profile.entity.ts
+++ b/libs/database/src/entities/learner-profile.entity.ts
@@ -1,12 +1,5 @@
-import {
-  ActionNameEnum,
-  BandScoreEnum,
-  ItemName,
-  MileStonesEnum,
-  ProfileItemStatusEnum,
-  RankEnum,
-} from "@app/types/enums";
-import { IActivity, ILearnerProfile, ILearnerProfileInfo, ILevel, IMileStoneInfo } from "@app/types/interfaces";
+import { ActionNameEnum, BandScoreEnum, ItemName, ProfileItemStatusEnum, RankEnum } from "@app/types/enums";
+import { IActivity, ILearnerProfile, ILearnerProfileInfo } from "@app/types/interfaces";
 import {
   BaseEntity,
   Column,
@@ -31,14 +24,13 @@ import { LessonProcess } from "./lesson-process.entity";
 import { LevelRankMap, NextBandScoreMap } from "@app/utils/maps";
 import { UpdateResourcesDto } from "@app/types/dtos/learners";
 import { Action } from "./action.entity";
-import { CompleteLessonDto } from "@app/types/dtos";
 import { Lesson } from "@app/database/entities/lesson.entity";
 import { QuestionType } from "@app/database/entities/question-type.entity";
-import { TMileStoneLearnProgress, TMileStoneProfile } from "@app/types/types";
 import moment from "moment-timezone";
 import { getBeginOfOffsetDay, getEndOfOffsetDay } from "@app/utils/time";
-import { VN_TIME_ZONE } from "@app/types/constants";
+import { BandScoreOrder, VN_TIME_ZONE } from "@app/types/constants";
 import { SkillTestSession } from "./test-sessions.entity";
+import { BadRequestException } from "@nestjs/common";
 
 @Entity("learner_profiles")
 export class LearnerProfile extends BaseEntity implements ILearnerProfile {
@@ -125,50 +117,6 @@ export class LearnerProfile extends BaseEntity implements ILearnerProfile {
     };
   }
 
-  public async getProfileMileStones(): Promise<TMileStoneProfile[]> {
-    const milestones: TMileStoneProfile[] = [];
-    const isLevelUp = await this.isLevelUp();
-    const isRankUp = this.isRankUp();
-    const isAchieveDailyStreak = await this.isAchieveDailyStreakOrCreate();
-    await this.save();
-    if (isLevelUp) {
-      const milestone: IMileStoneInfo<ILevel> = { type: MileStonesEnum.IS_LEVEL_UP, newValue: this.level };
-      milestones.push(milestone);
-    }
-
-    if (isRankUp) {
-      const milestone: IMileStoneInfo<RankEnum> = { type: MileStonesEnum.IS_RANK_UP, newValue: this.rank };
-      milestones.push(milestone);
-    }
-
-    if (isAchieveDailyStreak) {
-      const milestone: IMileStoneInfo<number> = { type: MileStonesEnum.IS_DAILY_STREAK, newValue: this.streak.current };
-      milestones.push(milestone);
-    }
-    return milestones;
-  }
-
-  public async getLearnProcessMileStones(
-    data: CompleteLessonDto,
-    xp: number,
-    questionTypeId: number
-  ): Promise<TMileStoneLearnProgress[]> {
-    const milestones: IMileStoneInfo<BandScoreEnum>[] = [];
-    const isBandScoreQuestionTypeUp = await this.isBandScoreQuestionTypeUp(
-      xp,
-      data.duration,
-      data.lessonId,
-      questionTypeId
-    );
-
-    isBandScoreQuestionTypeUp &&
-      milestones.push({
-        type: MileStonesEnum.IS_BAND_SCORE_QUESTION_TYPE_UP,
-        newValue: this.lessonProcesses.find((lesson) => lesson.questionTypeId === questionTypeId).bandScore,
-      });
-    return milestones;
-  }
-
   async isLevelUp(): Promise<boolean> {
     if (this.xp >= this.level.xp) {
       const nextLevel = await Level.findOne({ where: { id: this.levelId + 1 } });
@@ -223,20 +171,45 @@ export class LearnerProfile extends BaseEntity implements ILearnerProfile {
       (lessonProcess) => lessonProcess.questionTypeId === questionTypeId
     );
 
+    const currentLesson = await Lesson.findOne({ where: { id: completedLessonId } });
+
     if (currentQuestionTypeProcess === undefined) {
       currentQuestionTypeProcess = new LessonProcess({
         learnerProfile: this,
         questionTypeId: questionTypeId,
-        currentLesson: await Lesson.findOne({ where: { questionTypeId } }),
+        currentLesson,
         questionType: await QuestionType.findOne({ where: { id: questionTypeId } }),
         bandScore: BandScoreEnum.PRE_IELTS,
         xp: [],
       });
       this.lessonProcesses.push(currentQuestionTypeProcess);
+    } else if (
+      BandScoreOrder.indexOf(currentQuestionTypeProcess.bandScore) < BandScoreOrder.indexOf(currentLesson.bandScore)
+    ) {
+      throw new BadRequestException("you can not finish the lesson with higher band score level");
     }
 
     const currentBandScore = currentQuestionTypeProcess.bandScore;
+    if (BandScoreOrder.indexOf(currentLesson.bandScore) < BandScoreOrder.indexOf(currentBandScore)) {
+      let completedLessonProcess = currentQuestionTypeProcess.xp.find((p) => p.lessonId === completedLessonId);
+      if (!completedLessonProcess) {
+        completedLessonProcess = {
+          lessonId: completedLessonId,
+          xp,
+          duration,
+        };
+        currentQuestionTypeProcess.xp.push(completedLessonProcess);
+      } else {
+        const currentRequiredBandScore = currentQuestionTypeProcess.questionType.bandScoreRequires.find(
+          (require) => require.bandScore === currentLesson.bandScore
+        );
 
+        completedLessonProcess.xp = Math.max(completedLessonProcess.xp + xp, currentRequiredBandScore.requireXP);
+        completedLessonProcess.duration += duration;
+      }
+      await currentQuestionTypeProcess.save();
+      return false;
+    }
     await currentQuestionTypeProcess.updateLessonProcessOfLearner(xp, duration, completedLessonId);
     return (
       currentQuestionTypeProcess.bandScore !== currentBandScore &&

--- a/libs/database/src/entities/lesson-process.entity.ts
+++ b/libs/database/src/entities/lesson-process.entity.ts
@@ -104,7 +104,6 @@ export class LessonProcess extends BaseEntity implements ILessonProcess {
       const nextBandScore = NextBandScoreMap.get(this.bandScore);
       if (totalXP >= currentRequiredBandScore.requireXP && nextBandScore) {
         this.bandScore = nextBandScore;
-        this.xp = [];
       }
 
       await this.save();

--- a/libs/types/src/constants/band-score-order.constant.ts
+++ b/libs/types/src/constants/band-score-order.constant.ts
@@ -1,0 +1,11 @@
+import { BandScoreEnum } from "../enums";
+
+export const BandScoreOrder: BandScoreEnum[] = [
+  BandScoreEnum.PRE_IELTS,
+  BandScoreEnum.BAND_4_5,
+  BandScoreEnum.BAND_5_0,
+  BandScoreEnum.BAND_5_5,
+  BandScoreEnum.BAND_6_0,
+  BandScoreEnum.BAND_6_5,
+  BandScoreEnum.BAND_7_0,
+];

--- a/libs/types/src/constants/index.ts
+++ b/libs/types/src/constants/index.ts
@@ -19,3 +19,4 @@ export * from "./required-credential-evaluating.constant";
 export * from "./finished-status-group.constant";
 export * from "./mission-provider.constant";
 export * from "./public-key.constant";
+export * from "./band-score-order.constant";


### PR DESCRIPTION
- API to get list of band score, learners only see the list of band scores that are lower than the current

- Handle logic when complete a lesson:
1. Not empty the xp array of lesson process
2. When finish a lesson of lower band score, make sure just update the XP and duration of that lesson

- Modify API to get lessons of question types:  Provide query param for query list of lessons base on band score, the default will get the lesson of current band score.