### PR TITLE
feat(lap-761): update avatar for user when sign in with provider

### DIFF
--- a/apps/main-api/src/modules/auth/auth.module.ts
+++ b/apps/main-api/src/modules/auth/auth.module.ts
@@ -10,9 +10,19 @@ import { FirebaseStrategy } from "../../strategies";
 import { MailModule } from "@app/shared-modules/mail";
 import { RedisModule } from "@app/shared-modules/redis";
 import { NovuModule } from "@app/shared-modules/novu";
+import { BucketModule } from "../bucket/bucket.module";
 
 @Module({
-  imports: [PassportModule, DatabaseModule, FirebaseModule, ConfigModule, MailModule, RedisModule, NovuModule],
+  imports: [
+    PassportModule,
+    DatabaseModule,
+    FirebaseModule,
+    ConfigModule,
+    MailModule,
+    RedisModule,
+    NovuModule,
+    BucketModule,
+  ],
   controllers: [AuthController],
   providers: [AuthService, AuthHelper, FirebaseStrategy],
   exports: [AuthService],

--- a/apps/main-api/src/modules/auth/auth.service.spec.ts
+++ b/apps/main-api/src/modules/auth/auth.service.spec.ts
@@ -13,6 +13,10 @@ import { signInRequestMock, signUpRequestMock } from "./test/requests.mock";
 import { userStub } from "../user/test/user.stub";
 import { NovuService } from "@app/shared-modules/novu";
 import { NOVU_PROVIDER_TOKEN, REDIS_PROVIDER } from "@app/types/constants";
+import { ConfigService } from "@nestjs/config";
+import { S3_PROVIDER_NAME } from "../bucket/test/constants/s3-provider.const";
+import { S3 } from "@aws-sdk/client-s3";
+import { BucketService } from "../bucket/bucket.service";
 
 jest.mock("@app/shared-modules/firebase/firebase-auth.service");
 jest.mock("@app/shared-modules/mail");
@@ -25,6 +29,7 @@ describe("AuthService", function () {
   let authHelper: AuthHelper;
   let novuService: NovuService;
   let redisService: RedisService;
+  let bucketService: BucketService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -34,6 +39,17 @@ describe("AuthService", function () {
         FirebaseAuthService,
         RedisService,
         NovuService,
+        BucketService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: S3_PROVIDER_NAME,
+          useFactory: () => S3,
+        },
         {
           provide: getRepositoryToken(Account),
           useClass: Repository,
@@ -59,6 +75,7 @@ describe("AuthService", function () {
     firebaseAuthService = module.get<FirebaseAuthService>(FirebaseAuthService);
     novuService = module.get<NovuService>(NovuService);
     redisService = module.get<RedisService>(RedisService);
+    bucketService = module.get<BucketService>(BucketService);
   });
 
   it("should be defined", () => {
@@ -157,6 +174,11 @@ describe("AuthService", function () {
       } catch (e) {
         expect(e).toBeInstanceOf(BadRequestException);
       }
+    });
+  });
+  describe("sign in / sign up with provider", () => {
+    it("upload file from link should be defined", () => {
+      expect(bucketService.uploadAvatarFromLink).toBeDefined();
     });
   });
 });

--- a/apps/main-api/src/modules/user/test/user.service.spec.ts
+++ b/apps/main-api/src/modules/user/test/user.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { UserService } from "../user.service";
 import { FirebaseAuthService } from "@app/shared-modules/firebase";
+import { BucketService } from "../../bucket/bucket.service";
+import { ConfigService } from "@nestjs/config";
+import { S3_PROVIDER_NAME } from "../../bucket/test/constants/s3-provider.const";
+import { S3 } from "@aws-sdk/client-s3";
 
 describe("UserService", () => {
   let service: UserService;
@@ -9,6 +13,17 @@ describe("UserService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UserService,
+        BucketService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: S3_PROVIDER_NAME,
+          useFactory: () => S3,
+        },
         {
           provide: FirebaseAuthService,
           useValue: {

--- a/apps/main-api/src/modules/user/user.module.ts
+++ b/apps/main-api/src/modules/user/user.module.ts
@@ -4,9 +4,10 @@ import { UserController } from "./user.controller";
 import { UserService } from "./user.service";
 import { FirebaseModule } from "@app/shared-modules/firebase";
 import { AdminController } from "./admin.controller";
+import { BucketModule } from "../bucket/bucket.module";
 
 @Module({
-  imports: [FirebaseModule, ConfigModule],
+  imports: [FirebaseModule, ConfigModule, BucketModule],
   controllers: [UserController, AdminController],
   providers: [UserService],
 })

--- a/apps/main-api/src/modules/user/user.service.spec.ts
+++ b/apps/main-api/src/modules/user/user.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { UserService } from "./user.service";
 import { FirebaseAuthService } from "@app/shared-modules/firebase";
+import { ConfigService } from "@nestjs/config";
+import { S3_PROVIDER_NAME } from "../bucket/test/constants/s3-provider.const";
+import { S3 } from "@aws-sdk/client-s3";
+import { BucketService } from "../bucket/bucket.service";
 
 describe("UserService", () => {
   let service: UserService;
@@ -9,6 +13,18 @@ describe("UserService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UserService,
+        BucketService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: S3_PROVIDER_NAME,
+          useFactory: () => S3,
+        },
+
         {
           provide: FirebaseAuthService,
           useValue: {

--- a/libs/shared-modules/src/firebase/firebase-auth.service.ts
+++ b/libs/shared-modules/src/firebase/firebase-auth.service.ts
@@ -84,6 +84,16 @@ export class FirebaseAuthService {
     }
   }
 
+  async getUser(uid: string) {
+    try {
+      const auth = getAuth(this.app);
+      return auth.getUser(uid);
+    } catch (err) {
+      this.logger.error(err);
+      throw err;
+    }
+  }
+
   async verifyCustomToken(token: string) {
     try {
       const idToken = await this.getIdToken(token);

--- a/libs/types/src/constants/AI-evaluate-queue.constant.ts
+++ b/libs/types/src/constants/AI-evaluate-queue.constant.ts
@@ -1,4 +1,3 @@
 export const EVALUATE_SPEAKING_QUEUE = "evaluate-speaking-queue";
 export const EVALUATE_WRITING_QUEUE = "evaluate-writing-queue";
 export const PUSH_SPEAKING_FILE_QUEUE = "push-speaking-file-queue";
-export const PUSH_AVATARFILE_QUEUE = "push-avatar-file-queue";

--- a/libs/types/src/constants/AI-evaluate-queue.constant.ts
+++ b/libs/types/src/constants/AI-evaluate-queue.constant.ts
@@ -1,3 +1,4 @@
 export const EVALUATE_SPEAKING_QUEUE = "evaluate-speaking-queue";
 export const EVALUATE_WRITING_QUEUE = "evaluate-writing-queue";
 export const PUSH_SPEAKING_FILE_QUEUE = "push-speaking-file-queue";
+export const PUSH_AVATARFILE_QUEUE = "push-avatar-file-queue";

--- a/libs/types/src/dtos/accounts/log-in-with-provider.dto.ts
+++ b/libs/types/src/dtos/accounts/log-in-with-provider.dto.ts
@@ -2,6 +2,7 @@ import { IsNotEmpty, IsOptional, IsString, ValidateNested } from "class-validato
 import { ApiProperty } from "@nestjs/swagger";
 
 export class AdditionalInfo {
+  @IsOptional()
   @IsString()
   fullName: string;
 }


### PR DESCRIPTION
- When sign in with provider, check the photoUrl and current avatar of user. If users have not avatar, use the one from provider
- We can consider to use redis queue for push avatar file if the login with provider API is slow