### PR TITLE
feat(lap-770): handle logic jump band

### DIFF
--- a/apps/main-api/src/modules/daily-lesson/daily-lesson.controller.ts
+++ b/apps/main-api/src/modules/daily-lesson/daily-lesson.controller.ts
@@ -67,4 +67,12 @@ export class DailyLessonController {
   async getInstructionsByQuestionType(@Param("id", ParseIntPipe) id: number) {
     return this.dailyLessonService.getInstructionsOfQuestionType(id);
   }
+
+  @ApiOperation({ summary: "Get questions for jump band test" })
+  @ApiDefaultResponses()
+  @ApiParam({ name: "id", description: "Question type id", type: Number })
+  @Get("question-types/:id/band-upgrade-questions")
+  async getJumpBandQuestions(@Param("id", ParseIntPipe) id: number, @CurrentUser() currentUser: ICurrentUser) {
+    return this.dailyLessonService.getJumpBandQuestions(id, currentUser);
+  }
 }

--- a/libs/types/src/constants/default-band-score-requires.constant.ts
+++ b/libs/types/src/constants/default-band-score-requires.constant.ts
@@ -5,29 +5,36 @@ export const DEFAULT_BAND_SCORE_REQUIRES: IBandScoreRequire[] = [
   {
     bandScore: BandScoreEnum.PRE_IELTS,
     requireXP: 500,
+    jumpBandPercentage: 0.5,
   },
   {
     bandScore: BandScoreEnum.BAND_4_5,
     requireXP: 500,
+    jumpBandPercentage: 0.6,
   },
   {
     bandScore: BandScoreEnum.BAND_5_0,
     requireXP: 500,
+    jumpBandPercentage: 0.7,
   },
   {
     bandScore: BandScoreEnum.BAND_5_5,
     requireXP: 500,
+    jumpBandPercentage: 0.8,
   },
   {
     bandScore: BandScoreEnum.BAND_6_0,
     requireXP: 500,
+    jumpBandPercentage: 0.9,
   },
   {
     bandScore: BandScoreEnum.BAND_6_5,
     requireXP: 500,
+    jumpBandPercentage: 1,
   },
   {
     bandScore: BandScoreEnum.BAND_7_0,
     requireXP: 500,
+    jumpBandPercentage: 1,
   },
 ];

--- a/libs/types/src/constants/index.ts
+++ b/libs/types/src/constants/index.ts
@@ -19,3 +19,4 @@ export * from "./finished-status-group.constant";
 export * from "./mission-provider.constant";
 export * from "./public-key.constant";
 export * from "./band-score-order.constant";
+export * from "./jump-band-correct.constant";

--- a/libs/types/src/constants/jump-band-correct.constant.ts
+++ b/libs/types/src/constants/jump-band-correct.constant.ts
@@ -1,0 +1,1 @@
+export const REQUIRE_CORRECT_PERCENTAGE = 0.9;

--- a/libs/types/src/dtos/lessons/complete-lesson.dto.ts
+++ b/libs/types/src/dtos/lessons/complete-lesson.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsInt, Min } from "class-validator";
+import { IsBoolean, IsInt, IsOptional, Min } from "class-validator";
 
 export class CompleteLessonDto {
   @IsInt({ message: "Lesson ID must be an integer" })
@@ -29,4 +29,8 @@ export class CompleteLessonDto {
     example: 60,
   })
   duration: number; // in seconds
+
+  @IsOptional()
+  @IsBoolean({ message: "Jump band process must be boolean" })
+  isJumpBand: boolean = false;
 }

--- a/libs/types/src/interfaces/band-score-require.interface.ts
+++ b/libs/types/src/interfaces/band-score-require.interface.ts
@@ -3,4 +3,5 @@ import { BandScoreEnum } from "@app/types/enums";
 export interface IBandScoreRequire {
   bandScore: BandScoreEnum;
   requireXP: number;
+  jumpBandPercentage: number;
 }

--- a/scripts/sql/update-band-score-required.sql
+++ b/scripts/sql/update-band-score-required.sql
@@ -1,0 +1,38 @@
+UPDATE question_types
+SET band_score_requires = '[
+  {
+    "bandScore": "pre_ielts",
+    "requireXP": 500,
+    "jumpBandPercentage": 0.5
+  },
+  {
+    "bandScore": "4.5",
+    "requireXP": 500,
+    "jumpBandPercentage": 0.6
+  },
+  {
+    "bandScore": "5.0",
+    "requireXP": 500,
+    "jumpBandPercentage": 0.7
+  },
+  {
+    "bandScore": "5.5",
+    "requireXP": 500,
+    "jumpBandPercentage": 0.8
+  },
+  {
+    "bandScore": "6.0",
+    "requireXP": 500,
+    "jumpBandPercentage": 0.9
+  },
+  {
+    "bandScore": "6.5",
+    "requireXP": 500,
+    "jumpBandPercentage": 1
+  },
+  {
+    "bandScore": "7.0",
+    "requireXP": 500,
+    "jumpBandPercentage": 1
+  }
+]'


### PR DESCRIPTION
- Implement API to get questions for the jump band test

1. Get all questions from lessons of question types in current band score
2. Shuffle the questions and pick a number of questions randomly, the quantity is base on the config of each band score.
3. The return data will be the questions for doing test and the `id` of the last lesson in this band score, so after pass the jump band test, the current lesson of learner will be the last lesson of this question types.

- Update API handle complete lesson to check the jump band test

1.  Add property named `isJumpBand = true` in the request body if the completion is belonged to the jump band test
2. The system still check the milestones and missions, but in the jump band test, if there is no milestone for band score up, we should show the toast for learner that they can not move to next band
3. Learners need to have more than 90% of correct answers to move to the next band.

- Before testing, run sql script to update the band score requirements